### PR TITLE
Move command execution and logging logic to Runner class

### DIFF
--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -1,0 +1,51 @@
+require 'open3'
+
+module PerconaMigrator
+  class Runner
+
+    NONE = "\e[0m"
+    CYAN = "\e[38;5;86m"
+    GREEN = "\e[32m"
+    RED = "\e[31m"
+
+    def self.execute(command, logger)
+      new(command, logger).execute
+    end
+
+    def initialize(command, logger)
+      @command = command
+      @logger = logger
+      @status = nil
+    end
+
+    # Runs and logs the given command
+    #
+    # @return [Boolean]
+    def execute
+      log_started
+      run_command
+      log_finished
+
+      status
+    end
+
+    private
+
+    attr_reader :command, :logger, :status
+
+    def log_started
+      logger.puts "\n#{CYAN}-- #{command}#{NONE}\n\n"
+    end
+
+    def run_command
+      Open3.popen2(command) do |_stdin, stdout, process|
+        @status = process.value
+        logger.puts stdout.read
+      end
+    end
+
+    def log_finished
+      logger.puts(status ? "\n#{GREEN}Done!#{NONE}" : "\n#{RED}Failed!#{NONE}")
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -15,37 +15,37 @@ describe PerconaMigrator do
     let(:version) { 1 }
 
     describe 'command' do
-      before { allow(Kernel).to receive(:system) }
+      before { allow(PerconaMigrator::Runner).to receive(:execute) }
 
       it 'runs pt-online-schema-change' do
         described_class.migrate(version, direction, logger)
-        expect(Kernel).to(
-          have_received(:system)
-          .with(include('pt-online-schema-change'))
+        expect(PerconaMigrator::Runner).to(
+          have_received(:execute)
+          .with(include('pt-online-schema-change'), logger)
         )
       end
 
       it 'executes the migration' do
         described_class.migrate(version, direction, logger)
-        expect(Kernel).to(
-          have_received(:system)
-          .with(include('--execute'))
+        expect(PerconaMigrator::Runner).to(
+          have_received(:execute)
+          .with(include('--execute'), logger)
         )
       end
 
       it 'does not define --recursion-method' do
         described_class.migrate(version, direction, logger)
-        expect(Kernel).to(
-          have_received(:system)
-          .with(include('--recursion-method=none'))
+        expect(PerconaMigrator::Runner).to(
+          have_received(:execute)
+          .with(include('--recursion-method=none'), logger)
         )
       end
 
       it 'sets the --alter-foreign-keys-method option to auto' do
         described_class.migrate(version, direction, logger)
-        expect(Kernel).to(
-          have_received(:system)
-          .with(include('--alter-foreign-keys-method=auto'))
+        expect(PerconaMigrator::Runner).to(
+          have_received(:execute)
+          .with(include('--alter-foreign-keys-method=auto'), logger)
         )
       end
     end
@@ -91,7 +91,7 @@ describe PerconaMigrator do
 
     let(:version) { 1 }
 
-    before { allow(Kernel).to receive(:system) }
+    before { allow(PerconaMigrator::Runner).to receive(:execute) }
 
     before do
       allow(ENV).to receive(:[]).with('PERCONA_DB_HOST').and_return(host)
@@ -102,9 +102,9 @@ describe PerconaMigrator do
 
     it 'executes the percona command with the right connection details' do
       described_class.migrate(version, direction, logger)
-      expect(Kernel).to(
-        have_received(:system)
-        .with(include("-h #{host} -u #{user} -p #{password} D=#{db_name},t=comments" ))
+      expect(PerconaMigrator::Runner).to(
+        have_received(:execute)
+        .with(include("-h #{host} -u #{user} -p #{password} D=#{db_name},t=comments"), logger)
       )
     end
 
@@ -115,9 +115,9 @@ describe PerconaMigrator do
 
       it 'executes the percona command with the right connection details' do
         described_class.migrate(version, direction, logger)
-        expect(Kernel).to(
-          have_received(:system)
-          .with(include("-h #{host} -u #{user} D=#{db_name},t=comments"))
+        expect(PerconaMigrator::Runner).to(
+          have_received(:execute)
+          .with(include("-h #{host} -u #{user} D=#{db_name},t=comments"), logger)
         )
       end
     end

--- a/spec/percona_migrator_spec.rb
+++ b/spec/percona_migrator_spec.rb
@@ -6,27 +6,40 @@ describe PerconaMigrator do
   let(:logger) { double(:logger, puts: true) }
 
   describe '#migrate' do
-    before { allow(Kernel).to receive(:system) }
+      before { allow(PerconaMigrator::Runner).to receive(:execute) }
 
     it 'executes the pt-online-schema-change command' do
       PerconaMigrator.migrate(version, direction, logger)
-      expect(Kernel).to have_received(:system).with('pt-online-schema-change --execute --recursion-method=none --alter-foreign-keys-method=auto -h localhost -u root D=percona_migrator_test,t=comments --alter "add column \`some_id_field\` INT(11) DEFAULT NULL"')
+      expect(PerconaMigrator::Runner).to(
+        have_received(:execute)
+        .with('pt-online-schema-change --execute --recursion-method=none --alter-foreign-keys-method=auto -h localhost -u root D=percona_migrator_test,t=comments --alter "add column \`some_id_field\` INT(11) DEFAULT NULL"', logger)
+      )
     end
 
     context 'when pt-online-schema-change failed' do
       before do
-        allow(Kernel).to receive(:system).with('pt-online-schema-change --execute --recursion-method=none --alter-foreign-keys-method=auto -h localhost -u root D=percona_migrator_test,t=comments --alter "add column \`some_id_field\` INT(11) DEFAULT NULL"').and_return(false)
+        allow(PerconaMigrator::Runner).to(
+          receive(:execute)
+          .with('pt-online-schema-change --execute --recursion-method=none --alter-foreign-keys-method=auto -h localhost -u root D=percona_migrator_test,t=comments --alter "add column \`some_id_field\` INT(11) DEFAULT NULL"', logger).and_return(false)
+        )
       end
 
       it 'does not execute the mark_as_up rake task' do
         PerconaMigrator.migrate(version, direction, logger)
-        expect(Kernel).not_to have_received(:system).with("bundle exec rake db:migrate:mark_as_up VERSION=#{version}")
+        expect(PerconaMigrator::Runner).not_to(
+          have_received(:execute)
+          .with("bundle exec rake db:migrate:mark_as_up VERSION=#{version}", logger)
+        )
       end
     end
 
     context 'when pt-online-schema-change succeeded' do
       before do
-        allow(Kernel).to receive(:system).with('pt-online-schema-change --execute --recursion-method=none --alter-foreign-keys-method=auto -h localhost -u root D=percona_migrator_test,t=comments --alter "add column \`some_id_field\` INT(11) DEFAULT NULL"').and_return(true)
+        allow(PerconaMigrator::Runner).to(
+          receive(:execute)
+          .with('pt-online-schema-change --execute --recursion-method=none --alter-foreign-keys-method=auto -h localhost -u root D=percona_migrator_test,t=comments --alter "add column \`some_id_field\` INT(11) DEFAULT NULL"', logger)
+          .and_return(true)
+        )
       end
 
       it 'marks the migration as up' do


### PR DESCRIPTION
This allows us to suppress the output of the command while in the integration test. As a result, I managed to extract the logging and execution logic.
