### PR TITLE
DRY integration specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,12 @@ require './test_database'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec
 
 namespace :db do
   desc 'Create the test database'
   task :create do
     config = Configuration.new
-    TestDatabase.new(config).create_test_database
+    TestDatabase.new(config).setup_test_database
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 # TODO: Handle #change_table syntax
-describe PerconaMigrator do
+describe PerconaMigrator, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) { MIGRATION_FIXTURES }
@@ -28,7 +28,7 @@ describe PerconaMigrator do
     expect(PerconaMigrator::VERSION).not_to be nil
   end
 
-  context 'when ActiveRecord is loaded', integration: true do
+  context 'when ActiveRecord is loaded' do
     it 'reconnects to the database using PerconaAdapter' do
       ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
       expect(ActiveRecord::Base.connection_pool.spec.config[:adapter]).to eq('percona')
@@ -53,7 +53,7 @@ describe PerconaMigrator do
   context 'creating/removing columns' do
     let(:version) { 1 }
 
-    context 'creating column', integration: true do
+    context 'creating column' do
       let(:direction) { :up }
 
       it 'adds the column in the DB table' do
@@ -78,7 +78,7 @@ describe PerconaMigrator do
       end
     end
 
-    context 'droping column', integration: true do
+    context 'droping column' do
       let(:direction) { :down }
 
       before do
@@ -112,7 +112,7 @@ describe PerconaMigrator do
     end
   end
 
-  context 'adding/removing indexes', index: true do
+  context 'adding/removing indexes' do
     let(:version) { 2 }
 
     context 'adding indexes' do
@@ -191,7 +191,7 @@ describe PerconaMigrator do
     end
   end
 
-  context 'adding/removing unique indexes', index: true do
+  context 'adding/removing unique indexes' do
     let(:version) { 3 }
 
     context 'adding indexes' do

--- a/spec/lhm_integration_spec.rb
+++ b/spec/lhm_integration_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PerconaMigrator do
+describe PerconaMigrator, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
@@ -10,10 +10,10 @@ describe PerconaMigrator do
 
   before { ActiveRecord::Migration.verbose = false }
 
-  context 'creating/removing columns', ingreation: true do
+  context 'creating/removing columns' do
     let(:version) { 1 }
 
-    context 'creating column', index: true do
+    context 'creating column' do
       let(:direction) { :up }
 
       xit 'adds the column in the DB table' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,14 +41,9 @@ RSpec.configure do |config|
   # Cleans up the database after each example ala Database Cleaner
   config.around(:each) do |example|
     if example.metadata[:integration]
-      test_database.create_schema_migrations_table
-      example.run
-      test_database.create_schema_migrations_table
-    elsif example.metadata[:index]
       test_database.create_test_database
       test_database.create_schema_migrations_table
       example.run
-      test_database.create_test_database
     else
       example.run
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,24 +25,12 @@ MIGRATION_FIXTURES = File.expand_path('../fixtures/migrate/', __FILE__)
 test_database = TestDatabase.new(db_config)
 
 RSpec.configure do |config|
-  config.order = 'random'
-
-  config.before(:all) do
-    test_database.create_schema_migrations_table
-
-    @initial_migration_paths = ActiveRecord::Migrator.migrations_paths
-    ActiveRecord::Migrator.migrations_paths = [MIGRATION_FIXTURES]
-  end
-
-  config.after(:all) do
-    ActiveRecord::Migrator.migrations_paths = @initial_migration_paths
-  end
-
-  # Cleans up the database after each example ala Database Cleaner
   config.around(:each) do |example|
+
+    # Cleans up the database before each example, so the current example doesn't
+    # see the state of the previous one
     if example.metadata[:integration]
-      test_database.create_test_database
-      test_database.create_schema_migrations_table
+      test_database.setup
       example.run
     else
       example.run

--- a/test_database.rb
+++ b/test_database.rb
@@ -1,17 +1,33 @@
+# Setups the test database with the schema_migrations table that ActiveRecord
+# requires for the migrations, plus a table for the Comment model used throught
+# the tests.
+#
 class TestDatabase
+
+  # Constructor
+  #
+  # @param config [Hash]
   def initialize(config)
     @config = config
   end
 
-  # Creates the percona_migrator_test database and comments table in it
-  def create_test_database
-    %x(#{mysql_command} "DROP DATABASE IF EXISTS percona_migrator_test; CREATE DATABASE percona_migrator_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
-    %x(#{mysql_command} "USE percona_migrator_test; DROP TABLE IF EXISTS comments; CREATE TABLE comments (id int(12) NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;")
+  # Creates the test database, the schema_migrations and the comments tables.
+  # It drops any of them if they already exist
+  def setup
+    setup_test_database
+    drop_and_create_schema_migrations_table
+  end
+
+  # Creates the percona_migrator_test database and the comments table in it.
+  # Before, it drops both if they already exist
+  def setup_test_database
+    drop_and_create_test_database
+    drop_and_create_comments_table
   end
 
   # Creates the ActiveRecord's schema_migrations table required for
-  # migrations to work
-  def create_schema_migrations_table
+  # migrations to work. Before, it drops the table if it already exists
+  def drop_and_create_schema_migrations_table
     %x(#{mysql_command} "USE percona_migrator_test; DROP TABLE IF EXISTS schema_migrations; CREATE TABLE schema_migrations ( version varchar(255) COLLATE utf8_unicode_ci NOT NULL, UNIQUE KEY unique_schema_migrations (version)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci")
   end
 
@@ -19,6 +35,16 @@ class TestDatabase
 
   attr_reader :config
 
+  def drop_and_create_test_database
+    %x(#{mysql_command} "DROP DATABASE IF EXISTS percona_migrator_test; CREATE DATABASE percona_migrator_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci;")
+  end
+
+  def drop_and_create_comments_table
+    %x(#{mysql_command} "USE percona_migrator_test; DROP TABLE IF EXISTS comments; CREATE TABLE comments ( id int(12) NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;")
+  end
+
+  # Returns the command to run the mysql client. It uses the crendentials from
+  # the provided config
   def mysql_command
     "mysql --user=#{config['username']} --password=#{config['password']} -e"
   end


### PR DESCRIPTION
because now it's kind of a RSpec metadata mess. Besides, if percona failed, the spec still shows green. So we need to capture those "Segmentation fault signal 11" errors that percona gives.
