### PR TITLE
Support #execute including alter table statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Added
+
+- Support #execute. Allows to execute raw SQL from the migration
+
 ## [0.1.0.rc.2] - 2016-03-09
 
 ### Added

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -130,12 +130,17 @@ module ActiveRecord
         true
       end
 
-      def percona_execute(sql)
-        if sql =~ /alter table/i
+      # Executes the passed statement through pt-online-schema-change if it's
+      # an alter statement, or through the mysql adapter otherwise
+      #
+      # @param sql [String]
+      # @param name [String]
+      def percona_execute(sql, name)
+        if alter_statement?(sql)
           command = cli_generator.parse_statement(sql)
           runner.execute(command)
         else
-          mysql_adapter.execute(sql)
+          mysql_adapter.execute(sql, name)
         end
       end
 
@@ -151,6 +156,14 @@ module ActiveRecord
       private
 
       attr_reader :mysql_adapter, :logger, :runner, :cli_generator
+
+      # Checks whether the sql statement is an ALTER TABLE
+      #
+      # @param sql [String]
+      # @return [Boolean]
+      def alter_statement?(sql)
+        sql =~ /alter table/i
+      end
     end
   end
 end

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -130,6 +130,15 @@ module ActiveRecord
         true
       end
 
+      def percona_execute(sql)
+        if sql =~ /alter table/i
+          command = cli_generator.parse_statement(sql)
+          runner.execute(command)
+        else
+          mysql_adapter.execute(sql)
+        end
+      end
+
       # This abstract method leaves up to the connection adapter freeing the
       # result, if it needs to. Check out: https://github.com/rails/rails/blob/330c6af05c8b188eb072afa56c07d5fe15767c3c/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L247
       #

--- a/lib/percona_migrator/alter_argument.rb
+++ b/lib/percona_migrator/alter_argument.rb
@@ -3,6 +3,7 @@ module PerconaMigrator
   # Represents the '--alter' argument of Percona's pt-online-schema-change
   # See https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html
   class AlterArgument
+    ALTER_TABLE_REGEX = /ALTER TABLE `(\w+)` /
 
     # Constructor
     #
@@ -21,7 +22,7 @@ module PerconaMigrator
     #
     # @return [String]
     def table_name
-      statement.match(/ALTER TABLE `(\w+)` /).captures[0]
+      statement.match(ALTER_TABLE_REGEX).captures[0]
     end
 
     private
@@ -33,7 +34,7 @@ module PerconaMigrator
     # @return [String]
     def parsed_statement
       @parsed_statement ||= statement
-        .gsub(/ALTER TABLE `(\w+)` /, '')
+        .gsub(ALTER_TABLE_REGEX, '')
         .gsub('`','\\\`')
     end
   end

--- a/lib/percona_migrator/alter_argument.rb
+++ b/lib/percona_migrator/alter_argument.rb
@@ -17,6 +17,13 @@ module PerconaMigrator
       "--alter \"#{parsed_statement}\""
     end
 
+    # Returns the name of the table the alter statement refers to
+    #
+    # @return [String]
+    def table_name
+      statement.match(/ALTER TABLE `(\w+)` /).captures[0]
+    end
+
     private
 
     attr_reader :statement

--- a/lib/percona_migrator/cli_generator.rb
+++ b/lib/percona_migrator/cli_generator.rb
@@ -56,8 +56,23 @@ module PerconaMigrator
     # @param statement [String] MySQL statement
     # @return [String]
     def generate(table_name, statement)
-      dsn = DSN.new(database, table_name)
       alter_argument = AlterArgument.new(statement)
+      dsn = DSN.new(database, table_name)
+
+      "#{to_s} #{dsn} #{alter_argument}"
+    end
+
+    # Generates the percona command for a raw MySQL statement. Fills all the
+    # connection credentials from the current AR connection, but that can
+    # amended via ENV-vars: PERCONA_DB_HOST, PERCONA_DB_USER,
+    # PERCONA_DB_PASSWORD, PERCONA_DB_NAME Table name can't not be amended, it
+    # populates automatically from the migration data
+    #
+    # @param statement [String] MySQL statement
+    # @return [String]
+    def parse_statement(statement)
+      alter_argument = AlterArgument.new(statement)
+      dsn = DSN.new(database, alter_argument.table_name)
 
       "#{to_s} #{dsn} #{alter_argument}"
     end
@@ -79,6 +94,8 @@ module PerconaMigrator
     end
 
     # Returns the command as a string that can be executed in a shell
+    #
+    # @return [String]
     def to_s
       @command.join(' ')
     end

--- a/lib/percona_migrator/railtie.rb
+++ b/lib/percona_migrator/railtie.rb
@@ -44,9 +44,10 @@ module PerconaMigrator
           # This is because +pt-online-schema-change+ is intended for alter
           # statements only.
           #
-          # @param statement [String] MySQL statement
-          def execute(statement)
-            percona_execute(statement)
+          # @param sql [String]
+          # @param name [String] optional
+          def execute(sql, name = nil)
+            percona_execute(sql, name)
           end
         end
       end

--- a/lib/percona_migrator/railtie.rb
+++ b/lib/percona_migrator/railtie.rb
@@ -37,6 +37,17 @@ module PerconaMigrator
               connection_config.merge(adapter: 'percona')
             )
           end
+
+          # It executes the passed statement through the PerconaAdapter if it's
+          # an alter statement. It uses the mysql adapter otherwise.
+          #
+          # This is because +pt-online-schema-change+ is intended for alter
+          # statements only.
+          #
+          # @param statement [String] MySQL statement
+          def execute(statement)
+            percona_execute(statement)
+          end
         end
       end
     end

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -284,6 +284,8 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
   end
 
   describe '#percona_execute' do
+    let(:name) { nil }
+
     context 'when an alter statement is provided' do
       let(:table_name) { :comments }
       let(:statement) do
@@ -298,12 +300,26 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
 
       it 'passes the built SQL to the CliGenerator' do
         expect(cli_generator).to receive(:parse_statement).with(statement)
-        adapter.percona_execute(statement)
+        adapter.percona_execute(statement, name)
       end
 
       it 'runs the command' do
         expect(runner).to receive(:execute).with('percona command')
-        adapter.percona_execute(statement)
+        adapter.percona_execute(statement, name)
+      end
+
+      context 'and providing a name' do
+        let(:name) { 'name' }
+
+        it 'passes the built SQL to the CliGenerator' do
+          expect(cli_generator).to receive(:parse_statement).with(statement)
+          adapter.percona_execute(statement, name)
+        end
+
+        it 'runs the command' do
+          expect(runner).to receive(:execute).with('percona command')
+          adapter.percona_execute(statement, name)
+        end
       end
     end
 
@@ -311,8 +327,15 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
       let(:statement) { 'UPDATE comments SET some_id = NULL' }
 
       it 'delegates to the mysql adapter' do
-        expect(mysql_adapter).to receive(:execute).with(statement)
-        adapter.percona_execute(statement)
+        expect(mysql_adapter).to receive(:execute).with(statement, nil)
+        adapter.percona_execute(statement, nil)
+      end
+
+      context 'and providing a name' do
+        it 'delegates to the mysql adapter' do
+          expect(mysql_adapter).to receive(:execute).with(statement, 'name')
+          adapter.percona_execute(statement, 'name')
+        end
       end
     end
   end

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -282,4 +282,38 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
       adapter.create_table(table_name)
     end
   end
+
+  describe '#percona_execute' do
+    context 'when an alter statement is provided' do
+      let(:table_name) { :comments }
+      let(:statement) do
+        'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      end
+
+      before do
+        allow(cli_generator).to(
+          receive(:parse_statement).with(statement)
+        ).and_return('percona command')
+      end
+
+      it 'passes the built SQL to the CliGenerator' do
+        expect(cli_generator).to receive(:parse_statement).with(statement)
+        adapter.percona_execute(statement)
+      end
+
+      it 'runs the command' do
+        expect(runner).to receive(:execute).with('percona command')
+        adapter.percona_execute(statement)
+      end
+    end
+
+    context 'when a non-alter statement is provided' do
+      let(:statement) { 'UPDATE comments SET some_id = NULL' }
+
+      it 'delegates to the mysql adapter' do
+        expect(mysql_adapter).to receive(:execute).with(statement)
+        adapter.percona_execute(statement)
+      end
+    end
+  end
 end

--- a/spec/percona_migrator/alter_argument_spec.rb
+++ b/spec/percona_migrator/alter_argument_spec.rb
@@ -1,9 +1,31 @@
 require 'spec_helper'
 
 describe PerconaMigrator::AlterArgument do
-  let(:statement) { 'ADD INDEX dummy_index (some_id_field)' }
   let(:alter_argument) { described_class.new(statement) }
 
-  subject { alter_argument.to_s }
-  it { is_expected.to eq('--alter "ADD INDEX dummy_index (some_id_field)"') }
+  describe '#to_s' do
+    subject { alter_argument.to_s }
+
+    context 'when no ALTER TABLE is present' do
+      let(:statement) { 'ADD INDEX dummy_index (some_id_field)' }
+      it { is_expected.to eq('--alter "ADD INDEX dummy_index (some_id_field)"') }
+    end
+
+    context 'when there is an ALTER TABLE present' do
+      let(:statement) do
+        'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      end
+      it { is_expected.to eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"') }
+    end
+  end
+
+  describe '#table_name' do
+    subject { alter_argument.table_name }
+
+    let(:statement) do
+      'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+    end
+
+    it { is_expected.to eq('comments') }
+  end
 end


### PR DESCRIPTION
This basically allows to call `#execute` from a migration. If you included an alter statement, it'll go through Percona, otherwise it'll go through the regular mysql adapter instead.
