### PR TITLE
Include Foreigner Mysql2Adapter methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+- Support #drop_table
+- Support [Foreigner gem](https://github.com/matthuhiggins/foreigner) foreign
+    keys in Rails 3 apps that use it.
+
 ## [0.1.0.rc.3] - 2016-03-10
 
 ### Added
 
 - Support #execute. Allows to execute raw SQL from the migration
-- Support #drop_table
 
 ## [0.1.0.rc.2] - 2016-03-09
 

--- a/lib/percona_migrator/railtie.rb
+++ b/lib/percona_migrator/railtie.rb
@@ -25,8 +25,19 @@ module PerconaMigrator
           # @param direction [Symbol] :up or :down
           def migrate(direction)
             reconnect_with_percona
+            include_foreigner if defined?(Foreigner)
+
             ::Lhm.migration = self
             original_migrate(direction)
+          end
+
+          # Includes the Foreigner's Mysql2Adapter implemention in
+          # PerconaMigratorAdapter to support foreign keys
+          def include_foreigner
+            Foreigner::Adapter.safe_include(
+              :PerconaMigratorAdapter,
+              Foreigner::ConnectionAdapters::Mysql2Adapter
+            )
           end
 
           # Make all connections in the connection pool to use PerconaAdapter
@@ -38,8 +49,8 @@ module PerconaMigrator
             )
           end
 
-          # It executes the passed statement through the PerconaAdapter if it's
-          # an alter statement. It uses the mysql adapter otherwise.
+          # It executes the passed statement through the PerconaMigratorAdapter
+          # if it's an alter statement. It uses the mysql adapter otherwise.
           #
           # This is because +pt-online-schema-change+ is intended for alter
           # statements only.


### PR DESCRIPTION
This provides support for foreign keys in PerconaMigratorAdapter's
migrations in Rails 3.

If the app was using Foreigner already, we simply include Mysql2Adapter's implementation to PerconaMigratorAdapter
