### PR TITLE
Require all development gems with Bundler when running specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+Bundler.require(:default, :development)
+
 require './configuration'
 require './test_database'
-require 'rspec/its'
 
 require 'percona_migrator'
 require 'lhm'


### PR DESCRIPTION
So then we don't need to `require 'byebug'` where needed. All dev gems will be autorequired.
