### PR TITLE
Runner as connection client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Added
+
+- Support non-ddl migrations by implementing the methods for the ActiveRecord
+    quering to work.
+
+### Changed
+
+- Refactor the PerconaAdapter to use the Runner as connection client, as all the
+    other adapters.
+
 ## [0.1.0.rc.5] - 2016-03-29
 
 ### Changed
@@ -22,7 +32,7 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 - Support for foreing keys in db/schema.rb when using [Foreigner
 gem](https://github.com/matthuhiggins/foreigner) in Rails 3 apps. This allows to
 define foreign keys with #execute, but does not provide support for
-#add_foreign_key yet.
+add_foreign_key yet.
 
 ## [0.1.0.rc.3] - 2016-03-10
 

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -44,10 +44,9 @@ module ActiveRecord
 
       def_delegators :mysql_adapter, :last_inserted_id, :each_hash
 
-      def initialize(connection, logger, connection_options, _config)
+      def initialize(connection, _logger, connection_options, _config)
         super
         @mysql_adapter = connection_options[:mysql_adapter]
-        @logger = logger
       end
 
       def exec_delete(sql, name, binds)
@@ -112,7 +111,7 @@ module ActiveRecord
 
       private
 
-      attr_reader :mysql_adapter, :logger
+      attr_reader :mysql_adapter
     end
   end
 end

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -48,7 +48,7 @@ module ActiveRecord
 
       ADAPTER_NAME = 'Percona'.freeze
 
-      def_delegators :mysql_adapter, :last_inserted_id, :select
+      def_delegators :mysql_adapter, :last_inserted_id, :select, :each_hash
 
       def initialize(connection, logger, connection_options, config)
         super
@@ -81,17 +81,6 @@ module ActiveRecord
       # Returns true, as this adapter supports migrations
       def supports_migrations?
         true
-      end
-
-      # Delegates #each_hash to the mysql adapter
-      #
-      # @param result [Mysql2::Result]
-      def each_hash(result)
-        if block_given?
-          mysql_adapter.each_hash(result, &Proc.new)
-        else
-          mysql_adapter.each_hash(result)
-        end
       end
 
       def new_column(field, default, type, null, collation)
@@ -131,7 +120,9 @@ module ActiveRecord
         end
       end
 
-      def error_number(exception)
+      # Returns the MySQL error number from the exception. The
+      # AbstractMysqlAdapter requires it to be implemented
+      def error_number(_exception)
       end
 
       private

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -48,7 +48,7 @@ module ActiveRecord
 
       ADAPTER_NAME = 'Percona'.freeze
 
-      def_delegators :mysql_adapter, :last_inserted_id, :select, :each_hash
+      def_delegators :mysql_adapter, :last_inserted_id, :each_hash
 
       def initialize(connection, logger, connection_options, config)
         super
@@ -76,6 +76,12 @@ module ActiveRecord
       # array of field values.
       def select_rows(sql, name = nil)
         execute(sql, name).to_a
+      end
+
+      # Executes a SELECT query and returns an array of record hashes with the
+      # column names as keys and column values as values.
+      def select(sql, name = nil, binds = [])
+        exec_query(sql, name, binds).to_a
       end
 
       # Returns true, as this adapter supports migrations

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -131,15 +131,6 @@ module ActiveRecord
         end
       end
 
-      # This abstract method leaves up to the connection adapter freeing the
-      # result, if it needs to. Check out: https://github.com/rails/rails/blob/330c6af05c8b188eb072afa56c07d5fe15767c3c/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L247
-      #
-      # @param sql [String]
-      # @param name [String] optional
-      def execute_and_free(sql, name = nil)
-        yield mysql_adapter.execute(sql, name)
-      end
-
       def error_number(exception)
       end
 

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -46,6 +46,7 @@ module ActiveRecord
 
       def initialize(connection, _logger, connection_options, _config)
         super
+        @visitor = BindSubstitution.new(self)
         @mysql_adapter = connection_options[:mysql_adapter]
       end
 

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -9,10 +9,14 @@ module ActiveRecord
     # Establishes a connection to the database that's used by all Active
     # Record objects.
     def self.percona_connection(config)
-      connection = mysql2_connection(config)
-      client = connection.raw_connection
+      mysql2_connection = mysql2_connection(config)
+
       cli_generator = PerconaMigrator::CliGenerator.new(config)
-      runner = PerconaMigrator::Runner.new(logger, cli_generator)
+      runner = PerconaMigrator::Runner.new(
+        logger,
+        cli_generator,
+        mysql2_connection
+      )
 
       config.merge!(
         logger: logger,
@@ -20,7 +24,7 @@ module ActiveRecord
         cli_generator: cli_generator
       )
 
-      connection_options = { mysql_adapter: connection }
+      connection_options = { mysql_adapter: mysql2_connection }
 
       ConnectionAdapters::PerconaMigratorAdapter.new(
         runner,
@@ -45,8 +49,7 @@ module ActiveRecord
       ADAPTER_NAME = 'Percona'.freeze
 
       def_delegators :mysql_adapter, :tables, :select_values, :exec_delete,
-        :exec_insert, :exec_query, :last_inserted_id, :select, :create_table,
-        :drop_table
+        :exec_insert, :exec_query, :last_inserted_id, :select
 
       def initialize(connection, logger, connection_options, config)
         super

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -60,7 +60,7 @@ module ActiveRecord
         execute(to_sql(sql, binds), name)
       end
 
-      def exec_query(sql, name = 'SQL', binds = [])
+      def exec_query(sql, name = 'SQL', _binds = [])
         result = execute(sql, name)
         ActiveRecord::Result.new(result.fields, result.to_a)
       end

--- a/lib/percona_migrator/alter_argument.rb
+++ b/lib/percona_migrator/alter_argument.rb
@@ -22,7 +22,10 @@ module PerconaMigrator
     #
     # @return [String]
     def table_name
-      statement.match(ALTER_TABLE_REGEX).captures[0]
+      match = statement.match(ALTER_TABLE_REGEX)
+      raise StandardError, 'Invalid alter statement' unless match
+
+      match.captures[0]
     end
 
     private

--- a/lib/percona_migrator/alter_argument.rb
+++ b/lib/percona_migrator/alter_argument.rb
@@ -4,7 +4,7 @@ module PerconaMigrator
   # Represents the '--alter' argument of Percona's pt-online-schema-change
   # See https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html
   class AlterArgument
-    ALTER_TABLE_REGEX = /ALTER TABLE `(\w+)` /
+    ALTER_TABLE_REGEX = /\AALTER TABLE `(\w+)` /
 
     attr_reader :table_name
 

--- a/lib/percona_migrator/alter_argument.rb
+++ b/lib/percona_migrator/alter_argument.rb
@@ -1,31 +1,30 @@
 module PerconaMigrator
+  class InvalidAlterStatement < StandardError; end
 
   # Represents the '--alter' argument of Percona's pt-online-schema-change
   # See https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html
   class AlterArgument
     ALTER_TABLE_REGEX = /ALTER TABLE `(\w+)` /
 
+    attr_reader :table_name
+
     # Constructor
     #
     # @param statement [String]
+    # @raise [InvalidAlterStatement] if the statement is not an ALTER TABLE
     def initialize(statement)
       @statement = statement
+
+      match = statement.match(ALTER_TABLE_REGEX)
+      raise InvalidAlterStatement unless match
+
+      @table_name = match.captures[0]
     end
 
-    # Returns the '--alter' pt-online-schema-change argumment as a string. See
+    # Returns the '--alter' pt-online-schema-change argument as a string. See
     # https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html
     def to_s
       "--alter \"#{parsed_statement}\""
-    end
-
-    # Returns the name of the table the alter statement refers to
-    #
-    # @return [String]
-    def table_name
-      match = statement.match(ALTER_TABLE_REGEX)
-      raise StandardError, 'Invalid alter statement' unless match
-
-      match.captures[0]
     end
 
     private

--- a/lib/percona_migrator/railtie.rb
+++ b/lib/percona_migrator/railtie.rb
@@ -48,18 +48,6 @@ module PerconaMigrator
               connection_config.merge(adapter: 'percona')
             )
           end
-
-          # It executes the passed statement through the PerconaMigratorAdapter
-          # if it's an alter statement. It uses the mysql adapter otherwise.
-          #
-          # This is because +pt-online-schema-change+ is intended for alter
-          # statements only.
-          #
-          # @param sql [String]
-          # @param name [String] optional
-          def execute(sql, name = nil)
-            percona_execute(sql, name)
-          end
         end
       end
     end

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -47,15 +47,20 @@ module PerconaMigrator
     # Constructor
     #
     # @param logger [IO]
-    def initialize(logger, cli_generator)
+    def initialize(logger, cli_generator, mysql_adapter)
       @logger = logger
       @cli_generator = cli_generator
+      @mysql_adapter = mysql_adapter
       @status = nil
     end
 
     def query(sql)
-      command = cli_generator.parse_statement(sql)
-      execute(command)
+      if alter_statement?(sql)
+        command = cli_generator.parse_statement(sql)
+        execute(command)
+      else
+        mysql_adapter.execute(sql)
+      end
     end
 
     # Runs and logs the given command
@@ -70,7 +75,15 @@ module PerconaMigrator
 
     private
 
-    attr_reader :command, :logger, :status, :cli_generator
+    attr_reader :command, :logger, :status, :cli_generator, :mysql_adapter
+
+    # Checks whether the sql statement is an ALTER TABLE
+    #
+    # @param sql [String]
+    # @return [Boolean]
+    def alter_statement?(sql)
+      sql =~ /alter table/i
+    end
 
     # Logs the start and end of the execution
     #

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -90,7 +90,9 @@ module PerconaMigrator
 
     # Executes the command outputing any errors
     #
-    # @raise [Errno::ENOENT] if pt-online-schema-change can't be found
+    # @raise [NoStatusError] if the spawned process' status can't be retrieved
+    # @raise [SignalError] if the spawned process receives a signal
+    # @raise [CommandNotFoundError] if pt-online-schema-change can't be found
     def run_command
       message = nil
       Open3.popen3(command) do |_stdin, stdout, stderr, waith_thr|

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -54,6 +54,10 @@ module PerconaMigrator
       @status = nil
     end
 
+    # Executes the passed sql statement using pt-online-schema-change for ALTER
+    # TABLE statements, or the specified mysql adapter otherwise.
+    #
+    # @param sql [String]
     def query(sql)
       if alter_statement?(sql)
         command = cli_generator.parse_statement(sql)
@@ -63,6 +67,10 @@ module PerconaMigrator
       end
     end
 
+    # Returns the number of rows affected by the last UPDATE, DELETE or INSERT
+    # statements
+    #
+    # @return [Integer]
     def affected_rows
       mysql_adapter.raw_connection.affected_rows
     end

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -87,7 +87,7 @@ module PerconaMigrator
     # @param sql [String]
     # @return [Boolean]
     def alter_statement?(sql)
-      sql =~ /alter table/i
+      sql =~ /\Aalter table/i
     end
 
     # Logs the start and end of the execution

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -63,6 +63,11 @@ module PerconaMigrator
       end
     end
 
+    def affected_rows
+      mysql_adapter.raw_connection.affected_rows
+    end
+
+    # TODO: rename it so we don't confuse it with AR's #execute
     # Runs and logs the given command
     #
     # @param command [String]

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -47,9 +47,15 @@ module PerconaMigrator
     # Constructor
     #
     # @param logger [IO]
-    def initialize(logger)
+    def initialize(logger, cli_generator)
       @logger = logger
+      @cli_generator = cli_generator
       @status = nil
+    end
+
+    def query(sql)
+      command = cli_generator.parse_statement(sql)
+      execute(command)
     end
 
     # Runs and logs the given command
@@ -64,7 +70,7 @@ module PerconaMigrator
 
     private
 
-    attr_reader :command, :logger, :status
+    attr_reader :command, :logger, :status, :cli_generator
 
     # Logs the start and end of the execution
     #

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -37,13 +37,7 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
     )
   end
 
-  let(:config) do
-    {
-      prepared_statements: '',
-      runner: runner,
-      cli_generator: cli_generator
-    }
-  end
+  let(:config) { { prepared_statements: '', runner: runner } }
 
   let(:adapter) do
     described_class.new(runner, logger, connection_options, config)
@@ -240,63 +234,6 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
       is_expected.to match_array(
         [{"id"=>"1", "body"=>"body"}, {"id"=>"2", "body"=>"body"}]
       )
-    end
-  end
-
-  describe '#percona_execute' do
-    let(:name) { nil }
-
-    context 'when an alter statement is provided' do
-      let(:table_name) { :comments }
-      let(:statement) do
-        'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
-      end
-
-      before do
-        allow(cli_generator).to(
-          receive(:parse_statement).with(statement)
-        ).and_return('percona command')
-      end
-
-      it 'passes the built SQL to the CliGenerator' do
-        expect(cli_generator).to receive(:parse_statement).with(statement)
-        adapter.percona_execute(statement, name)
-      end
-
-      it 'runs the command' do
-        expect(runner).to receive(:execute).with('percona command')
-        adapter.percona_execute(statement, name)
-      end
-
-      context 'and providing a name' do
-        let(:name) { 'name' }
-
-        it 'passes the built SQL to the CliGenerator' do
-          expect(cli_generator).to receive(:parse_statement).with(statement)
-          adapter.percona_execute(statement, name)
-        end
-
-        it 'runs the command' do
-          expect(runner).to receive(:execute).with('percona command')
-          adapter.percona_execute(statement, name)
-        end
-      end
-    end
-
-    context 'when a non-alter statement is provided' do
-      let(:statement) { 'UPDATE comments SET some_id = NULL' }
-
-      it 'delegates to the mysql adapter' do
-        expect(mysql_adapter).to receive(:execute).with(statement, nil)
-        adapter.percona_execute(statement, nil)
-      end
-
-      context 'and providing a name' do
-        it 'delegates to the mysql adapter' do
-          expect(mysql_adapter).to receive(:execute).with(statement, 'name')
-          adapter.percona_execute(statement, 'name')
-        end
-      end
     end
   end
 end

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -213,26 +213,6 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
     end
   end
 
-  describe '#create_table' do
-    let(:table_name) { :comments }
-    let(:options) { {} }
-
-    it 'delegates to the mysql adapter' do
-      expect(mysql_adapter).to receive(:create_table).with(table_name)
-      adapter.create_table(table_name)
-    end
-  end
-
-  describe '#drop_table' do
-    let(:table_name) { :comments }
-    let(:options) { {} }
-
-    it 'delegates to the mysql adapter' do
-      expect(mysql_adapter).to receive(:drop_table).with(table_name)
-      adapter.drop_table(table_name)
-    end
-  end
-
   describe '#percona_execute' do
     let(:name) { nil }
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -258,11 +258,6 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
         adapter.percona_execute(statement, name)
       end
 
-      it 'logs the execution' do
-        expect(adapter).to receive(:log).with(statement, nil)
-        adapter.percona_execute(statement, name)
-      end
-
       context 'and providing a name' do
         let(:name) { 'name' }
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -128,26 +128,6 @@ describe ActiveRecord::ConnectionAdapters::PerconaMigratorAdapter do
     end
   end
 
-  describe '#execute_and_free' do
-    let(:mysql_adapter) do
-      instance_double(
-        ActiveRecord::ConnectionAdapters::Mysql2Adapter,
-        raw_connection: true,
-        execute: true
-      )
-    end
-
-    it 'yields the mysql adapter execution result' do
-      expect(mysql_adapter).to(
-        receive(:execute).with('a sql statement', nil)
-      ).and_return('yielded')
-
-      adapter.execute_and_free('a sql statement') do |result|
-        expect(result).to eq('yielded')
-      end
-    end
-  end
-
   describe '#exec_delete' do
     let(:sql) { 'DELETE FROM comments WHERE id = 1' }
     let(:name) { nil }

--- a/spec/fixtures/migrate/10_data_migration_with_find_each.rb
+++ b/spec/fixtures/migrate/10_data_migration_with_find_each.rb
@@ -1,0 +1,15 @@
+class DataMigrationWithFindEach < ActiveRecord::Migration
+  class Comment < ActiveRecord::Base; end
+
+  def up
+    unread_comments = Comment.where(read: false)
+
+    unread_comments.find_each do |unread_comment|
+      unread_comment.read = true
+      unread_comment.save
+    end
+  end
+
+  def down
+  end
+end

--- a/spec/fixtures/migrate/11_data_migration_with_question_mark_interpolation.rb
+++ b/spec/fixtures/migrate/11_data_migration_with_question_mark_interpolation.rb
@@ -1,0 +1,11 @@
+class DataMigrationWithQuestionMarkInterpolation < ActiveRecord::Migration
+  class Comment < ActiveRecord::Base; end
+
+  def up
+    unread_comments = Comment.where('`read` = ?', false)
+    unread_comments.update_all(read: true)
+  end
+
+  def down
+  end
+end

--- a/spec/fixtures/migrate/12_data_migration_with_named_binds.rb
+++ b/spec/fixtures/migrate/12_data_migration_with_named_binds.rb
@@ -1,0 +1,11 @@
+class DataMigrationWithNamedBinds < ActiveRecord::Migration
+  class Comment < ActiveRecord::Base; end
+
+  def up
+    unread_comments = Comment.where('`read` = :read', read: false)
+    unread_comments.update_all(read: true)
+  end
+
+  def down
+  end
+end

--- a/spec/fixtures/migrate/9_data_migration_with_update_all.rb
+++ b/spec/fixtures/migrate/9_data_migration_with_update_all.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithWhere < ActiveRecord::Migration
+class DataMigrationWithUpdateAll < ActiveRecord::Migration
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/9_data_migration_with_where.rb
+++ b/spec/fixtures/migrate/9_data_migration_with_where.rb
@@ -1,0 +1,11 @@
+class DataMigrationWithWhere < ActiveRecord::Migration
+  class Comment < ActiveRecord::Base; end
+
+  def up
+    unread_comments = Comment.where(read: false)
+    unread_comments.update_all(read: true)
+  end
+
+  def down
+  end
+end

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -68,4 +68,52 @@ describe PerconaMigrator, integration: true do
       expect(ActiveRecord::Migrator.current_version).to eq(version)
     end
   end
+
+  context 'running a migration with ? interpolation' do
+    let(:version) { 11 }
+
+    it 'updates all the required data' do
+      ActiveRecord::Migrator.run(
+        direction,
+        [migration_fixtures],
+        version
+      )
+
+      expect(Comment.pluck(:read)).to match_array([true, true])
+    end
+
+    it 'marks the migration as up' do
+      ActiveRecord::Migrator.run(
+        direction,
+        [migration_fixtures],
+        version
+      )
+
+      expect(ActiveRecord::Migrator.current_version).to eq(version)
+    end
+  end
+
+  context 'running a migration with named bind variables' do
+    let(:version) { 12 }
+
+    it 'updates all the required data' do
+      ActiveRecord::Migrator.run(
+        direction,
+        [migration_fixtures],
+        version
+      )
+
+      expect(Comment.pluck(:read)).to match_array([true, true])
+    end
+
+    it 'marks the migration as up' do
+      ActiveRecord::Migrator.run(
+        direction,
+        [migration_fixtures],
+        version
+      )
+
+      expect(ActiveRecord::Migrator.current_version).to eq(version)
+    end
+  end
 end

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe PerconaMigrator, integration: true do
+  class Comment < ActiveRecord::Base; end
+
+  let(:migration_fixtures) { MIGRATION_FIXTURES }
+
+  context 'running a migration with #where' do
+    let(:version) { 9 }
+    let(:direction) { :up }
+
+    before do
+      ActiveRecord::Base.connection.add_column(
+        :comments,
+        :read,
+        :boolean,
+        default: false,
+        null: false
+      )
+
+      Comment.create(read: false)
+      Comment.create(read: false)
+    end
+
+    it 'marks the migration as up' do
+      ActiveRecord::Migrator.run(
+        direction,
+        [migration_fixtures],
+        version
+      )
+
+      expect(ActiveRecord::Migrator.current_version).to eq(version)
+    end
+
+    it 'updates all the required data' do
+      ActiveRecord::Migrator.run(
+        direction,
+        [migration_fixtures],
+        version
+      )
+
+      expect(Comment.pluck(:read)).to match_array([true, true])
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -238,7 +238,7 @@ describe PerconaMigrator, integration: true do
     end
   end
 
-  context 'creating a table', index: true do
+  context 'creating a table' do
     let(:version) { 8 }
 
     it 'creates the table' do
@@ -252,7 +252,7 @@ describe PerconaMigrator, integration: true do
     end
   end
 
-  context 'dropping a table', index: true do
+  context 'dropping a table' do
     let(:version) { 8 }
     let(:direction) { :down }
 

--- a/spec/percona_migrator/alter_argument_spec.rb
+++ b/spec/percona_migrator/alter_argument_spec.rb
@@ -27,5 +27,13 @@ describe PerconaMigrator::AlterArgument do
     end
 
     it { is_expected.to eq('comments') }
+
+    context 'when the statement is invalid' do
+      let(:statement) { 'CREATE TABLE `things`' }
+
+      it 'raises a StandardError' do
+        expect { alter_argument.table_name }.to raise_error(StandardError)
+      end
+    end
   end
 end

--- a/spec/percona_migrator/alter_argument_spec.rb
+++ b/spec/percona_migrator/alter_argument_spec.rb
@@ -3,19 +3,33 @@ require 'spec_helper'
 describe PerconaMigrator::AlterArgument do
   let(:alter_argument) { described_class.new(statement) }
 
+  describe '#initialize' do
+    subject { described_class.new(statement) }
+
+    context 'when the statement is invalid' do
+      let(:statement) { 'CREATE TABLE `things`' }
+
+      it 'raises a InvalidAlterStatement' do
+        expect { described_class.new(statement) }.to(
+          raise_error(PerconaMigrator::InvalidAlterStatement)
+        )
+      end
+    end
+  end
+
   describe '#to_s' do
     subject { alter_argument.to_s }
-
-    context 'when no ALTER TABLE is present' do
-      let(:statement) { 'ADD INDEX dummy_index (some_id_field)' }
-      it { is_expected.to eq('--alter "ADD INDEX dummy_index (some_id_field)"') }
-    end
 
     context 'when there is an ALTER TABLE present' do
       let(:statement) do
         'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
       end
-      it { is_expected.to eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"') }
+
+      it do
+        is_expected.to(
+          eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
+        )
+      end
     end
   end
 
@@ -27,13 +41,5 @@ describe PerconaMigrator::AlterArgument do
     end
 
     it { is_expected.to eq('comments') }
-
-    context 'when the statement is invalid' do
-      let(:statement) { 'CREATE TABLE `things`' }
-
-      it 'raises a StandardError' do
-        expect { alter_argument.table_name }.to raise_error(StandardError)
-      end
-    end
   end
 end

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -4,8 +4,11 @@ describe PerconaMigrator::Runner do
   let(:command) { 'pt-online-schema-change command' }
   let(:logger) { instance_double(Logger, info: true) }
   let(:cli_generator) { instance_double(PerconaMigrator::CliGenerator) }
+  let(:mysql_adapter) do
+    instance_double(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+  end
 
-  let(:runner) { described_class.new(logger, cli_generator) }
+  let(:runner) { described_class.new(logger, cli_generator, mysql_adapter) }
 
   describe '#execute' do
     let(:status) do

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -10,6 +10,22 @@ describe PerconaMigrator::Runner do
 
   let(:runner) { described_class.new(logger, cli_generator, mysql_adapter) }
 
+  describe '#query' do
+  end
+
+  describe '#affected_rows' do
+    let(:mysql_client) { double(:mysql_client) }
+
+    before do
+      allow(mysql_adapter).to receive(:raw_connection).and_return(mysql_client)
+    end
+
+    it 'delegates to the MySQL adapter\'s client' do
+      expect(mysql_client).to receive(:affected_rows)
+      runner.affected_rows
+    end
+  end
+
   describe '#execute' do
     let(:status) do
       instance_double(

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe PerconaMigrator::Runner do
   let(:command) { 'pt-online-schema-change command' }
   let(:logger) { instance_double(Logger, info: true) }
+  let(:cli_generator) { instance_double(PerconaMigrator::CliGenerator) }
 
-  let(:runner) { described_class.new(logger) }
+  let(:runner) { described_class.new(logger, cli_generator) }
 
   describe '#execute' do
     let(:status) do


### PR DESCRIPTION
This is an attempt of refactoring the adapter by implementing `#query` in `Runner`. This is the method all underlying connection clients implement and gets called by ActiveRecord to finally execute the SQL statement.

By folllowing the AR's way and reducing the coupling with the mysql2 adapter, we'll make the percona adapter my flexible and more robust.
## Implementation

Now, as `@connection` contains the actual `Runner` instance, the `AbstractMysqlAdapter#execute` method calls it for us wrapping any raised exceptions.

When the received sql is an ALTER TABLE statement it goes through `pt-online-schema-change`, spawning a process and so on. Otherwise, it delegates the execution to the mysql adapter, as they would have gone without percona.

EDIT

Yay! we got regular data migrations working already :tada:!
