### PR TITLE
Show commands stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Added
+
+- Toggle pt-online-schema-change's output as well when toggling the migration's
+    verbose option.
+
+### Changed
+
+- Enabled pt-online-schema-change's output while running the migration, that got
+  broken in v0.1.0.rc.2
+
 ## [0.1.0.rc.6] - 2016-04-07
 
 ### Added

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -11,9 +11,10 @@ module ActiveRecord
     def self.percona_connection(config)
       mysql2_connection = mysql2_connection(config)
 
+      percona_logger = PerconaMigrator::Logger.new(verbose: config[:verbose])
       cli_generator = PerconaMigrator::CliGenerator.new(config)
       runner = PerconaMigrator::Runner.new(
-        PerconaMigrator::Logger.new,
+        percona_logger,
         cli_generator,
         mysql2_connection
       )

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -11,13 +11,9 @@ module ActiveRecord
     def self.percona_connection(config)
       mysql2_connection = mysql2_connection(config)
 
-      percona_logger = if config[:verbose]
-        PerconaMigrator::Logger.new
-      else
-        PerconaMigrator::NullLogger.new
-      end
-
+      percona_logger = PerconaMigrator::LoggerFactory.build(config)
       cli_generator = PerconaMigrator::CliGenerator.new(config)
+
       runner = PerconaMigrator::Runner.new(
         percona_logger,
         cli_generator,

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -11,8 +11,12 @@ module ActiveRecord
     def self.percona_connection(config)
       mysql2_connection = mysql2_connection(config)
 
-      # TODO: if don't want verbose, do not create any instance
-      percona_logger = PerconaMigrator::Logger.new(verbose: config[:verbose])
+      percona_logger = if config[:verbose]
+        PerconaMigrator::Logger.new
+      else
+        PerconaMigrator::NullLogger.new
+      end
+
       cli_generator = PerconaMigrator::CliGenerator.new(config)
       runner = PerconaMigrator::Runner.new(
         percona_logger,

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -11,7 +11,8 @@ module ActiveRecord
     def self.percona_connection(config)
       mysql2_connection = mysql2_connection(config)
 
-      percona_logger = PerconaMigrator::LoggerFactory.build(config)
+      verbose = ActiveRecord::Migration.verbose
+      percona_logger = PerconaMigrator::LoggerFactory.build(verbose: verbose)
       cli_generator = PerconaMigrator::CliGenerator.new(config)
 
       runner = PerconaMigrator::Runner.new(

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
       cli_generator = PerconaMigrator::CliGenerator.new(config)
       runner = PerconaMigrator::Runner.new(
-        logger,
+        PerconaMigrator::Logger.new,
         cli_generator,
         mysql2_connection
       )

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -11,6 +11,7 @@ module ActiveRecord
     def self.percona_connection(config)
       mysql2_connection = mysql2_connection(config)
 
+      # TODO: if don't want verbose, do not create any instance
       percona_logger = PerconaMigrator::Logger.new(verbose: config[:verbose])
       cli_generator = PerconaMigrator::CliGenerator.new(config)
       runner = PerconaMigrator::Runner.new(

--- a/lib/percona_migrator.rb
+++ b/lib/percona_migrator.rb
@@ -4,6 +4,7 @@ require 'active_support/all'
 require 'percona_migrator/version'
 require 'percona_migrator/runner'
 require 'percona_migrator/cli_generator'
+require 'percona_migrator/logger'
 
 require 'percona_migrator/railtie' if defined?(Rails)
 

--- a/lib/percona_migrator.rb
+++ b/lib/percona_migrator.rb
@@ -6,6 +6,7 @@ require 'percona_migrator/runner'
 require 'percona_migrator/cli_generator'
 require 'percona_migrator/logger'
 require 'percona_migrator/null_logger'
+require 'percona_migrator/logger_factory'
 
 require 'percona_migrator/railtie' if defined?(Rails)
 

--- a/lib/percona_migrator.rb
+++ b/lib/percona_migrator.rb
@@ -5,6 +5,7 @@ require 'percona_migrator/version'
 require 'percona_migrator/runner'
 require 'percona_migrator/cli_generator'
 require 'percona_migrator/logger'
+require 'percona_migrator/null_logger'
 
 require 'percona_migrator/railtie' if defined?(Rails)
 

--- a/lib/percona_migrator/logger.rb
+++ b/lib/percona_migrator/logger.rb
@@ -3,9 +3,6 @@ module PerconaMigrator
   # status. It's not possible to reuse the from ActiveRecord::Migration because
   # the migration's instance can't be seen from the connection adapter.
   class Logger
-    def initialize(verbose: true)
-      @verbose = verbose
-    end
 
     # Outputs the message through the stdout, following the
     # ActiveRecord::Migration log format
@@ -20,11 +17,7 @@ module PerconaMigrator
     #
     # @param text [String]
     def write(text = '')
-      puts(text) if verbose
+      puts(text)
     end
-
-    private
-
-    attr_reader :verbose
   end
 end

--- a/lib/percona_migrator/logger.rb
+++ b/lib/percona_migrator/logger.rb
@@ -1,0 +1,23 @@
+module PerconaMigrator
+  # Copies the ActiveRecord::Migration #say and #write to log the migration's
+  # status. It's not possible to reuse the from ActiveRecord::Migration because
+  # the migration's instance can't be seen from the connection adapter.
+  class Logger
+
+    # Outputs the message through the stdout, following the
+    # ActiveRecord::Migration log format
+    #
+    # @param message [String]
+    # @param subitem [Boolean] whether to show message as a nested log item
+    def say(message, subitem = false)
+      write "#{subitem ? "   ->" : "--"} #{message}"
+    end
+
+    # Outputs the text through the stdout
+    #
+    # @param text [String]
+    def write(text = '')
+      puts(text)
+    end
+  end
+end

--- a/lib/percona_migrator/logger.rb
+++ b/lib/percona_migrator/logger.rb
@@ -3,6 +3,9 @@ module PerconaMigrator
   # status. It's not possible to reuse the from ActiveRecord::Migration because
   # the migration's instance can't be seen from the connection adapter.
   class Logger
+    def initialize(verbose: true)
+      @verbose = verbose
+    end
 
     # Outputs the message through the stdout, following the
     # ActiveRecord::Migration log format
@@ -17,7 +20,11 @@ module PerconaMigrator
     #
     # @param text [String]
     def write(text = '')
-      puts(text)
+      puts(text) if verbose
     end
+
+    private
+
+    attr_reader :verbose
   end
 end

--- a/lib/percona_migrator/logger_factory.rb
+++ b/lib/percona_migrator/logger_factory.rb
@@ -4,11 +4,9 @@ module PerconaMigrator
     # Returns the appropriate logger instance for the given configuration. Use
     # :verbose option to log to the stdout
     #
-    # @param config [Hash]
+    # @param verbose [Boolean]
     # @return [#say, #write]
-    def self.build(config)
-      verbose = config.fetch(:verbose, true)
-
+    def self.build(verbose: true)
       if verbose
         PerconaMigrator::Logger.new
       else

--- a/lib/percona_migrator/logger_factory.rb
+++ b/lib/percona_migrator/logger_factory.rb
@@ -1,0 +1,19 @@
+module PerconaMigrator
+  module LoggerFactory
+
+    # Returns the appropriate logger instance for the given configuration. Use
+    # :verbose option to log to the stdout
+    #
+    # @param config [Hash]
+    # @return [#say, #write]
+    def self.build(config)
+      verbose = config.fetch(:verbose, true)
+
+      if verbose
+        PerconaMigrator::Logger.new
+      else
+        PerconaMigrator::NullLogger.new
+      end
+    end
+  end
+end

--- a/lib/percona_migrator/null_logger.rb
+++ b/lib/percona_migrator/null_logger.rb
@@ -1,0 +1,11 @@
+module PerconaMigrator
+  class NullLogger
+    def say(_message, _subitem = false)
+      # noop
+    end
+
+    def write(_text)
+      # noop
+    end
+  end
+end

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -40,13 +40,12 @@ module PerconaMigrator
   class Runner
     COMMAND_NOT_FOUND = 127
 
-    NONE = "\e[0m"
-    CYAN = "\e[38;5;86m"
-    GREEN = "\e[32m"
-
     # Constructor
     #
-    # @param logger [IO]
+    # @param logger [#say]
+    # @param cli_generator [CliGenerator]
+    # @param mysql_adapter [ActiveRecord::ConnectionAdapter] it must implement
+    #   #execute and #raw_connection
     def initialize(logger, cli_generator, mysql_adapter)
       @logger = logger
       @cli_generator = cli_generator
@@ -107,11 +106,9 @@ module PerconaMigrator
       log_finished
     end
 
-    # TODO: log as a migration logger subitem
-    #
     # Logs when the execution started
     def log_started
-      logger.info "\n#{CYAN}-- #{command}#{NONE}\n\n"
+      logger.say("Running #{command}", true)
     end
 
     # Executes the command outputing any errors
@@ -124,7 +121,7 @@ module PerconaMigrator
       Open3.popen3(command) do |_stdin, stdout, stderr, waith_thr|
         @status = waith_thr.value
         message = stderr.read
-        logger.info(stdout.read)
+        logger.write(stdout.read)
       end
 
       raise NoStatusError if status.nil?
@@ -137,7 +134,7 @@ module PerconaMigrator
     # Logs the status of the execution once it's finished. At this point we
     # know it's a success
     def log_finished
-      logger.info("\n#{GREEN}Done!#{NONE}")
+      logger.say("Done!")
     end
   end
 end

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -42,7 +42,7 @@ module PerconaMigrator
 
     # Constructor
     #
-    # @param logger [#say]
+    # @param logger [#say, #write]
     # @param cli_generator [CliGenerator]
     # @param mysql_adapter [ActiveRecord::ConnectionAdapter] it must implement
     #   #execute and #raw_connection

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -26,21 +26,33 @@ describe PerconaMigrator, integration: true do
     expect(PerconaMigrator::VERSION).not_to be nil
   end
 
-  context 'when the migration logging is enabled' do
-    before { ActiveRecord::Migration.verbose = true }
+  describe 'logging' do
+    context 'when the migration logging is enabled' do
+      around(:each) do |example|
+        original_verbose = ActiveRecord::Migration.verbose
+        ActiveRecord::Migration.verbose = true
+        example.run
+        ActiveRecord::Migration.verbose = original_verbose
+      end
 
-    it 'sends the output to the stdout' do
-      expect($stdout).to receive(:puts).at_least(:once)
-      ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+      it 'sends the output to the stdout' do
+        expect($stdout).to receive(:puts).at_least(:once)
+        ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+      end
     end
-  end
 
-  context 'when the migration logging is disabled' do
-    before { ActiveRecord::Migration.verbose = false }
+    context 'when the migration logging is disabled' do
+      around(:each) do |example|
+        original_verbose = ActiveRecord::Migration.verbose
+        ActiveRecord::Migration.verbose = false
+        example.run
+        ActiveRecord::Migration.verbose = original_verbose
+      end
 
-    it 'sends the output to the stdout' do
-      expect($stdout).not_to receive(:puts)
-      ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+      it 'sends the output to the stdout' do
+        expect($stdout).not_to receive(:puts)
+        ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+      end
     end
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -22,8 +22,6 @@ describe PerconaMigrator, integration: true do
 
   let(:direction) { :up }
 
-  before { ActiveRecord::Migration.verbose = false }
-
   it 'has a version number' do
     expect(PerconaMigrator::VERSION).not_to be nil
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -28,6 +28,24 @@ describe PerconaMigrator, integration: true do
     expect(PerconaMigrator::VERSION).not_to be nil
   end
 
+  context 'when the migration logging is enabled' do
+    before { ActiveRecord::Migration.verbose = true }
+
+    it 'sends the output to the stdout' do
+      expect($stdout).to receive(:puts).at_least(:once)
+      ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+    end
+  end
+
+  context 'when the migration logging is disabled' do
+    before { ActiveRecord::Migration.verbose = false }
+
+    it 'sends the output to the stdout' do
+      expect($stdout).not_to receive(:puts)
+      ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+    end
+  end
+
   context 'when ActiveRecord is loaded' do
     it 'reconnects to the database using PerconaAdapter' do
       ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate

--- a/spec/lhm_integration_spec.rb
+++ b/spec/lhm_integration_spec.rb
@@ -8,8 +8,6 @@ describe PerconaMigrator, integration: true do
   end
   let(:direction) { :up }
 
-  before { ActiveRecord::Migration.verbose = false }
-
   context 'creating/removing columns' do
     let(:version) { 1 }
 

--- a/spec/percona_migrator/logger_factory_spec.rb
+++ b/spec/percona_migrator/logger_factory_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe PerconaMigrator::LoggerFactory do
+  describe '.build' do
+    subject { described_class.build(config) }
+
+    context 'when :verbose is set as true' do
+      let(:config) { { verbose: true } }
+      it { is_expected.to be_a(PerconaMigrator::Logger) }
+    end
+
+    context 'when :verbose is set as false' do
+      let(:config) { { verbose: false } }
+      it { is_expected.to be_a(PerconaMigrator::NullLogger) }
+    end
+
+    context 'when :verbose is not specified' do
+      let(:config) { {} }
+      it { is_expected.to be_a(PerconaMigrator::Logger) }
+    end
+  end
+end

--- a/spec/percona_migrator/logger_factory_spec.rb
+++ b/spec/percona_migrator/logger_factory_spec.rb
@@ -2,20 +2,19 @@ require 'spec_helper'
 
 describe PerconaMigrator::LoggerFactory do
   describe '.build' do
-    subject { described_class.build(config) }
 
     context 'when :verbose is set as true' do
-      let(:config) { { verbose: true } }
+      subject { described_class.build(verbose: true) }
       it { is_expected.to be_a(PerconaMigrator::Logger) }
     end
 
     context 'when :verbose is set as false' do
-      let(:config) { { verbose: false } }
+      subject { described_class.build(verbose: false) }
       it { is_expected.to be_a(PerconaMigrator::NullLogger) }
     end
 
     context 'when :verbose is not specified' do
-      let(:config) { {} }
+      subject { described_class.build }
       it { is_expected.to be_a(PerconaMigrator::Logger) }
     end
   end

--- a/spec/percona_migrator/logger_spec.rb
+++ b/spec/percona_migrator/logger_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe PerconaMigrator::Logger do
+  let(:logger) { described_class.new }
+
+  describe '#say' do
+    let(:message) { 'a random message' }
+
+    context 'when the subitem options is not specified' do
+      it 'prints the message to the stdout' do
+        expect(logger).to receive(:puts).with("-- #{message}")
+        logger.say(message)
+      end
+    end
+
+    context 'when the subitem option is specified as false' do
+      it 'prints the message to the stdout' do
+        expect(logger).to receive(:puts).with("-- #{message}")
+        logger.say(message, false)
+      end
+    end
+
+    context 'when the subitem option is specified as true' do
+      it 'prints the message to the stdout' do
+        expect(logger).to receive(:puts).with("   -> #{message}")
+        logger.say(message, true)
+      end
+    end
+  end
+
+  describe '#write' do
+    let(:text) { 'a text' }
+
+    it 'prints the text to the stdout' do
+      expect(logger).to receive(:puts).with(text)
+      logger.write(text)
+    end
+  end
+end

--- a/spec/percona_migrator/logger_spec.rb
+++ b/spec/percona_migrator/logger_spec.rb
@@ -27,22 +27,9 @@ describe PerconaMigrator::Logger do
       end
     end
 
-    context 'when verbose is true' do
-      let(:logger) { described_class.new(verbose: true) }
-
-      it 'enables the output to the stdout' do
-        expect(logger).to receive(:puts).with(/random message/)
-        logger.say('random message')
-      end
-    end
-
-    context 'when verbose is false' do
-      let(:logger) { described_class.new(verbose: false) }
-
-      it 'disables the output to the stdout' do
-        expect(logger).not_to receive(:puts).with(/random message/)
-        logger.say('random message')
-      end
+    it 'sends the output to the stdout' do
+      expect(logger).to receive(:puts).with(/random message/)
+      logger.say('random message')
     end
   end
 

--- a/spec/percona_migrator/logger_spec.rb
+++ b/spec/percona_migrator/logger_spec.rb
@@ -26,6 +26,24 @@ describe PerconaMigrator::Logger do
         logger.say(message, true)
       end
     end
+
+    context 'when verbose is true' do
+      let(:logger) { described_class.new(verbose: true) }
+
+      it 'enables the output to the stdout' do
+        expect(logger).to receive(:puts).with(/random message/)
+        logger.say('random message')
+      end
+    end
+
+    context 'when verbose is false' do
+      let(:logger) { described_class.new(verbose: false) }
+
+      it 'disables the output to the stdout' do
+        expect(logger).not_to receive(:puts).with(/random message/)
+        logger.say('random message')
+      end
+    end
   end
 
   describe '#write' do

--- a/spec/percona_migrator/null_logger_spec.rb
+++ b/spec/percona_migrator/null_logger_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe PerconaMigrator::NullLogger do
+  let(:null_logger) { described_class.new }
+  let(:message) { 'a message' }
+
+  describe '#say' do
+    subject { null_logger.say(message) }
+    it { is_expected.to eq(nil) }
+  end
+
+  describe '#write' do
+    subject { null_logger.write(message) }
+    it { is_expected.to eq(nil) }
+  end
+end

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -60,18 +60,21 @@ describe PerconaMigrator::Runner do
 
     it 'logs that the execution started' do
       runner.execute(command)
-      expect(logger).to have_received(:write).with('command output')
+      expect(logger).to have_received(:say).with(
+        "Running pt-online-schema-change command\n\n",
+        true
+      )
     end
 
-    it 'logs that the command\'s output' do
+    it 'logs the command\'s output' do
       runner.execute(command)
       expect(logger).to have_received(:write).with('command output')
     end
 
     context 'when the execution was succsessfull' do
-      it 'logs it as success' do
+      it 'prints a new line' do
         runner.execute(command)
-        expect(logger).to have_received(:say).with(/Done!/)
+        expect(logger).to have_received(:write).twice.with(/\n/)
       end
     end
 

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe PerconaMigrator::Runner do
   let(:command) { 'pt-online-schema-change command' }
-  let(:logger) { instance_double(Logger, info: true) }
+  let(:logger) do
+    instance_double(ActiveRecord::Migration, write: true, say: true)
+  end
   let(:cli_generator) { instance_double(PerconaMigrator::CliGenerator) }
   let(:mysql_adapter) do
     instance_double(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
@@ -58,18 +60,18 @@ describe PerconaMigrator::Runner do
 
     it 'logs that the execution started' do
       runner.execute(command)
-      expect(logger).to have_received(:info).with('command output')
+      expect(logger).to have_received(:write).with('command output')
     end
 
     it 'logs that the command\'s output' do
       runner.execute(command)
-      expect(logger).to have_received(:info).with('command output')
+      expect(logger).to have_received(:write).with('command output')
     end
 
     context 'when the execution was succsessfull' do
       it 'logs it as success' do
         runner.execute(command)
-        expect(logger).to have_received(:info).with(/Done!/)
+        expect(logger).to have_received(:say).with(/Done!/)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,8 @@ MIGRATION_FIXTURES = File.expand_path('../fixtures/migrate/', __FILE__)
 test_database = TestDatabase.new(db_config)
 
 RSpec.configure do |config|
+  ActiveRecord::Migration.verbose = false
+
   config.around(:each) do |example|
 
     # Cleans up the database before each example, so the current example doesn't

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,8 @@ ActiveRecord::Base.establish_connection(
   host: 'localhost',
   username: db_config['username'],
   password: db_config['password'],
-  database: 'percona_migrator_test'
+  database: 'percona_migrator_test',
+  verbose: false
 )
 
 MIGRATION_FIXTURES = File.expand_path('../fixtures/migrate/', __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,7 @@ ActiveRecord::Base.establish_connection(
   host: 'localhost',
   username: db_config['username'],
   password: db_config['password'],
-  database: 'percona_migrator_test',
-  verbose: false
+  database: 'percona_migrator_test'
 )
 
 MIGRATION_FIXTURES = File.expand_path('../fixtures/migrate/', __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'lhm'
 
 db_config = Configuration.new
 
+# Disables/enables the queries log you see in your rails server in dev mode
 fd = ENV['VERBOSE'] ? STDOUT : '/dev/null'
 ActiveRecord::Base.logger = Logger.new(fd)
 


### PR DESCRIPTION
I broke the output some time ago, while trying to remove it in the integration specs. This enables it back and changes the formatting a little bit. This is how it looks now:

http://cl.ly/213l1n2N462t

This also uses `ActiveRecord::Migration.verbose` to enable/disable pt-online-schema-change's output. This way when you want to disable the migration's output you won't its logs either.
