### PR TITLE
Adds info message when using percona migrator

### DIFF
--- a/lib/percona_migrator/logger_factory.rb
+++ b/lib/percona_migrator/logger_factory.rb
@@ -7,6 +7,7 @@ module PerconaMigrator
     # @param verbose [Boolean]
     # @return [#say, #write]
     def self.build(verbose: true)
+      puts("Migrations will execute with PerconaMigrator\nfor more information visit https://github.com/redbooth/percona_migrator")
       if verbose
         PerconaMigrator::Logger.new
       else

--- a/lib/percona_migrator/logger_factory.rb
+++ b/lib/percona_migrator/logger_factory.rb
@@ -7,8 +7,8 @@ module PerconaMigrator
     # @param verbose [Boolean]
     # @return [#say, #write]
     def self.build(verbose: true)
-      puts("Migrations will execute with PerconaMigrator\nfor more information visit https://github.com/redbooth/percona_migrator")
       if verbose
+        puts("Migrations will execute with PerconaMigrator\nfor more information visit https://github.com/redbooth/percona_migrator")
         PerconaMigrator::Logger.new
       else
         PerconaMigrator::NullLogger.new

--- a/spec/percona_migrator/logger_factory_spec.rb
+++ b/spec/percona_migrator/logger_factory_spec.rb
@@ -17,7 +17,7 @@ describe PerconaMigrator::LoggerFactory do
       subject { described_class.build(verbose: false) }
       it { is_expected.to be_a(PerconaMigrator::NullLogger) }
       it 'tells the user when PerconaMigrator is being used' do
-        expect(described_class).to receive(:puts).with(expected_info_message)
+        expect(described_class).not_to receive(:puts)
         subject
       end
     end

--- a/spec/percona_migrator/logger_factory_spec.rb
+++ b/spec/percona_migrator/logger_factory_spec.rb
@@ -2,20 +2,33 @@ require 'spec_helper'
 
 describe PerconaMigrator::LoggerFactory do
   describe '.build' do
+    let(:expected_info_message) { "Migrations will execute with PerconaMigrator\nfor more information visit https://github.com/redbooth/percona_migrator" }
 
     context 'when :verbose is set as true' do
       subject { described_class.build(verbose: true) }
       it { is_expected.to be_a(PerconaMigrator::Logger) }
+      it 'tells the user when PerconaMigrator is being used' do
+        expect(described_class).to receive(:puts).with(expected_info_message)
+        subject
+      end
     end
 
     context 'when :verbose is set as false' do
       subject { described_class.build(verbose: false) }
       it { is_expected.to be_a(PerconaMigrator::NullLogger) }
+      it 'tells the user when PerconaMigrator is being used' do
+        expect(described_class).to receive(:puts).with(expected_info_message)
+        subject
+      end
     end
 
     context 'when :verbose is not specified' do
       subject { described_class.build }
       it { is_expected.to be_a(PerconaMigrator::Logger) }
+      it 'tells the user when PerconaMigrator is being used' do
+        expect(described_class).to receive(:puts).with(expected_info_message)
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
As a ActiveRecord user
I want to see when PerconaMigrator is being used
So that I know my migrations will use PerconaMigrator

I've added this simple logging every time the logger is created to notify users when Percona Migrator is being used instead of the default one.
