### PR TITLE
Improved logging management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 .byebug_history
 tags
+percona_migrator_error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
     of at then and all at once.
 - Store pt-online-schema-change's stderr to percona_migrator_error.log in the
     default Rails tmp folder.
-- Allow configuring the tmp path with the `tmp_path` configuration setting.
+- Allow configuring the tmp directory where the error log gets written into,
+    with the `tmp_path` configuration setting.
 
 ## [0.1.0.rc.7] - 2016-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Added
+
+- Show pt-online-schema-change's stdout while the migration is running instead
+    of at then and all at once.
+- Store pt-online-schema-change's stderr to percona_migrator_error.log in the
+    default Rails tmp folder.
+- Allow configuring the tmp path with the `tmp_path` configuration setting.
+
 ## [0.1.0.rc.7] - 2016-09-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ statements also go through `pt-online-schema-change` as well.
 You can keep your Lhm migrations and start using Rails migration's DSL back
 again in your next migration.
 
+## Configuration
+
+You can override any of the default values from an initializer:
+
+```ruby
+PerconaMigrator.configure do |config|
+  config.tmp_path = '/tmp/example'
+end
+```
+
+It's strongly recommended to name it after this gems name, such as
+`config/initializers/percona_migrator.rb`
+
 ## How it works
 
 When booting your Rails app, Percona Migrator extends the

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can override any of the default values from an initializer:
 
 ```ruby
 PerconaMigrator.configure do |config|
-  config.tmp_path = '/tmp/example'
+  config.tmp_path = '/tmp/'
 end
 ```
 

--- a/lib/percona_migrator.rb
+++ b/lib/percona_migrator.rb
@@ -7,8 +7,16 @@ require 'percona_migrator/cli_generator'
 require 'percona_migrator/logger'
 require 'percona_migrator/null_logger'
 require 'percona_migrator/logger_factory'
+require 'percona_migrator/configuration'
 
 require 'percona_migrator/railtie' if defined?(Rails)
 
 module PerconaMigrator
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.config
+    self.configuration ||= Configuration.new
+  end
 end

--- a/lib/percona_migrator.rb
+++ b/lib/percona_migrator.rb
@@ -8,6 +8,7 @@ require 'percona_migrator/logger'
 require 'percona_migrator/null_logger'
 require 'percona_migrator/logger_factory'
 require 'percona_migrator/configuration'
+require 'percona_migrator/errors'
 
 require 'percona_migrator/railtie' if defined?(Rails)
 

--- a/lib/percona_migrator.rb
+++ b/lib/percona_migrator.rb
@@ -16,7 +16,8 @@ module PerconaMigrator
     attr_accessor :configuration
   end
 
-  def self.config
+  def self.configure
     self.configuration ||= Configuration.new
+    yield(configuration)
   end
 end

--- a/lib/percona_migrator.rb
+++ b/lib/percona_migrator.rb
@@ -12,6 +12,9 @@ require 'percona_migrator/errors'
 
 require 'percona_migrator/railtie' if defined?(Rails)
 
+# We need the OS not to buffer the IO to see pt-osc's output while migrating
+$stdout.sync = true
+
 module PerconaMigrator
   class << self
     attr_accessor :configuration

--- a/lib/percona_migrator/configuration.rb
+++ b/lib/percona_migrator/configuration.rb
@@ -3,7 +3,16 @@ module PerconaMigrator
     attr_accessor :tmp_path
 
     def initialize
-      @tmp_path = 'percona_migrator_error.log'.freeze
+      @tmp_path = '.'.freeze
+      @error_log_filename = 'percona_migrator_error.log'.freeze
     end
+
+    def error_log_path
+      File.join(tmp_path, error_log_filename)
+    end
+
+    private
+
+    attr_reader :error_log_filename
   end
 end

--- a/lib/percona_migrator/configuration.rb
+++ b/lib/percona_migrator/configuration.rb
@@ -1,0 +1,9 @@
+module PerconaMigrator
+  class Configuration
+    attr_accessor :tmp_path
+
+    def initialize
+      @tmp_path = 'percona_migrator_error.log'.freeze
+    end
+  end
+end

--- a/lib/percona_migrator/errors.rb
+++ b/lib/percona_migrator/errors.rb
@@ -1,0 +1,35 @@
+module PerconaMigrator
+  class Error < StandardError; end
+
+  # Used when for whatever reason we couldn't get the spawned process'
+  # status.
+  class NoStatusError < Error
+    def message
+      'Status could not be retrieved'.freeze
+    end
+  end
+
+  # Used when the spawned process failed by receiving a signal.
+  # pt-online-schema-change returns "SIGSEGV (signal 11)" on failures.
+  class SignalError < Error
+    attr_reader :status
+
+    # Constructor
+    #
+    # @param status [Process::Status]
+    def initialize(status)
+      super
+      @status = status
+    end
+
+    def message
+      status.to_s
+    end
+  end
+
+  class CommandNotFoundError < Error
+    def message
+      'Please install pt-online-schema-change. Check: https://www.percona.com/doc/percona-toolkit for further details'
+    end
+  end
+end

--- a/lib/percona_migrator/logger.rb
+++ b/lib/percona_migrator/logger.rb
@@ -1,7 +1,8 @@
 module PerconaMigrator
-  # Copies the ActiveRecord::Migration #say and #write to log the migration's
-  # status. It's not possible to reuse the from ActiveRecord::Migration because
-  # the migration's instance can't be seen from the connection adapter.
+  # Copies the ActiveRecord::Migration #say and #write plus a new
+  # #write_no_newline to log the migration's status. It's not possible to reuse
+  # the from ActiveRecord::Migration because the migration's instance can't be
+  # seen from the connection adapter.
   class Logger
 
     # Outputs the message through the stdout, following the
@@ -13,11 +14,18 @@ module PerconaMigrator
       write "#{subitem ? "   ->" : "--"} #{message}"
     end
 
-    # Outputs the text through the stdout
+    # Outputs the text through the stdout adding a new line at the end
     #
     # @param text [String]
     def write(text = '')
       puts(text)
+    end
+
+    # Outputs the text through the stdout without adding a new line at the end
+    #
+    # @param text [String]
+    def write_no_newline(text)
+      print(text)
     end
   end
 end

--- a/lib/percona_migrator/null_logger.rb
+++ b/lib/percona_migrator/null_logger.rb
@@ -7,5 +7,9 @@ module PerconaMigrator
     def write(_text)
       # noop
     end
+
+    def write_no_newline(_text)
+      # noop
+    end
   end
 end

--- a/lib/percona_migrator/railtie.rb
+++ b/lib/percona_migrator/railtie.rb
@@ -51,5 +51,11 @@ module PerconaMigrator
         end
       end
     end
+
+    initializer 'percona_migrator.configure' do |app|
+      PerconaMigrator.configure do |config|
+        config.tmp_path = app.paths['tmp'].first
+      end
+    end
   end
 end

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -88,7 +88,7 @@ module PerconaMigrator
           loop do
             IO.select([stdout])
             data = stdout.read_nonblock(8)
-            logger.write data
+            logger.write_no_newline(data)
           end
         rescue EOFError
           # noop

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -46,11 +46,12 @@ module PerconaMigrator
     # @param cli_generator [CliGenerator]
     # @param mysql_adapter [ActiveRecord::ConnectionAdapter] it must implement
     #   #execute and #raw_connection
-    def initialize(logger, cli_generator, mysql_adapter)
+    def initialize(logger, cli_generator, mysql_adapter, config = PerconaMigrator.config)
       @logger = logger
       @cli_generator = cli_generator
       @mysql_adapter = mysql_adapter
       @status = nil
+      @config = config
     end
 
     # Executes the passed sql statement using pt-online-schema-change for ALTER
@@ -88,7 +89,7 @@ module PerconaMigrator
 
     private
 
-    attr_reader :command, :logger, :status, :cli_generator, :mysql_adapter
+    attr_reader :command, :logger, :status, :cli_generator, :mysql_adapter, :config
 
     # Checks whether the sql statement is an ALTER TABLE
     #
@@ -149,11 +150,9 @@ module PerconaMigrator
 
     # The path where the percona toolkit stderr will be written
     #
-    # TODO: move to Rails tmp folder
-    #
     # @return [String]
     def error_log_path
-      'percona_migrator_error.log'
+      config.tmp_path
     end
 
     # @return [String]

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -152,7 +152,7 @@ module PerconaMigrator
     #
     # @return [String]
     def error_log_path
-      config.tmp_path
+      config.error_log_path
     end
 
     # @return [String]

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -46,7 +46,7 @@ module PerconaMigrator
     # @param cli_generator [CliGenerator]
     # @param mysql_adapter [ActiveRecord::ConnectionAdapter] it must implement
     #   #execute and #raw_connection
-    def initialize(logger, cli_generator, mysql_adapter, config = PerconaMigrator.config)
+    def initialize(logger, cli_generator, mysql_adapter, config = PerconaMigrator.configuration)
       @logger = logger
       @cli_generator = cli_generator
       @mysql_adapter = mysql_adapter

--- a/lib/percona_migrator/runner.rb
+++ b/lib/percona_migrator/runner.rb
@@ -1,39 +1,6 @@
 require 'open3'
 
 module PerconaMigrator
-  class Error < StandardError; end
-
-  # Used when for whatever reason we couldn't get the spawned process'
-  # status.
-  class NoStatusError < Error
-    def message
-      'Status could not be retrieved'.freeze
-    end
-  end
-
-  # Used when the spawned process failed by receiving a signal.
-  # pt-online-schema-change returns "SIGSEGV (signal 11)" on failures.
-  class SignalError < Error
-    attr_reader :status
-
-    # Constructor
-    #
-    # @param status [Process::Status]
-    def initialize(status)
-      super
-      @status = status
-    end
-
-    def message
-      status.to_s
-    end
-  end
-
-  class CommandNotFoundError < Error
-    def message
-      'Please install pt-online-schema-change. Check: https://www.percona.com/doc/percona-toolkit for further details'
-    end
-  end
 
   # It executes pt-online-schema-change commands in a new process and gets its
   # output and status

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -36,8 +36,9 @@ describe PerconaMigrator, integration: true do
       end
 
       it 'sends the output to the stdout' do
-        expect($stdout).to receive(:puts).at_least(:once)
-        ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+        expect do
+          ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+        end.to output.to_stdout
       end
     end
 
@@ -50,8 +51,9 @@ describe PerconaMigrator, integration: true do
       end
 
       it 'sends the output to the stdout' do
-        expect($stdout).not_to receive(:puts)
-        ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+        expect do
+          ActiveRecord::Migrator.new(direction, [migration_fixtures], 1).migrate
+        end.to_not output.to_stdout
       end
     end
   end

--- a/spec/percona_migrator/configuration_spec.rb
+++ b/spec/percona_migrator/configuration_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe PerconaMigrator::Configuration do
+  describe '#initialize' do
+    its(:tmp_path) { is_expected.to eq('percona_migrator_error.log') }
+  end
+
+  describe '#tmp_path' do
+    subject { described_class.new.tmp_path }
+    it { is_expected.to eq('percona_migrator_error.log') }
+  end
+
+  describe '#tmp_path=' do
+    subject { described_class.new.tmp_path = 'foo.log' }
+    it { is_expected.to eq('foo.log') }
+  end
+end

--- a/spec/percona_migrator/configuration_spec.rb
+++ b/spec/percona_migrator/configuration_spec.rb
@@ -2,16 +2,17 @@ require 'spec_helper'
 
 describe PerconaMigrator::Configuration do
   describe '#initialize' do
-    its(:tmp_path) { is_expected.to eq('percona_migrator_error.log') }
+    its(:tmp_path) { is_expected.to eq('.') }
+    its(:error_log_filename) { is_expected.to eq('percona_migrator_error.log') }
   end
 
   describe '#tmp_path' do
     subject { described_class.new.tmp_path }
-    it { is_expected.to eq('percona_migrator_error.log') }
+    it { is_expected.to eq('.') }
   end
 
   describe '#tmp_path=' do
-    subject { described_class.new.tmp_path = 'foo.log' }
-    it { is_expected.to eq('foo.log') }
+    subject { described_class.new.tmp_path = '/tmp' }
+    it { is_expected.to eq('/tmp') }
   end
 end

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -4,7 +4,12 @@ require 'tempfile'
 describe PerconaMigrator::Runner do
   let(:command) { 'pt-online-schema-change command' }
   let(:logger) do
-    instance_double(ActiveRecord::Migration, write: true, say: true)
+    instance_double(
+      PerconaMigrator::Logger,
+      write: true,
+      write_no_newline: true,
+      say: true
+    )
   end
   let(:cli_generator) { instance_double(PerconaMigrator::CliGenerator) }
   let(:mysql_adapter) do
@@ -85,9 +90,9 @@ describe PerconaMigrator::Runner do
       runner.execute(command)
 
       expect(logger).to have_received(:write).with("\n").twice
-      expect(logger).to have_received(:write).with("hello wo")
-      expect(logger).to have_received(:write).with("rld\\ntod")
-      expect(logger).to have_received(:write).with("o roto")
+      expect(logger).to have_received(:write_no_newline).with("hello wo")
+      expect(logger).to have_received(:write_no_newline).with("rld\\ntod")
+      expect(logger).to have_received(:write_no_newline).with("o roto")
     end
 
     context 'when the execution was succsessfull' do

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -107,9 +107,8 @@ describe PerconaMigrator::Runner do
         let(:command) { 'sh -c \'echo ROTO >/dev/stderr && false\'' }
 
         it 'raises a PerconaMigrator::Error' do
-          expect { runner.execute(command) }.to(
-            raise_exception(PerconaMigrator::Error, "ROTO\n")
-          )
+          expect { runner.execute(command) }
+            .to raise_exception(PerconaMigrator::Error, "ROTO\n")
         end
       end
 
@@ -117,9 +116,8 @@ describe PerconaMigrator::Runner do
         let(:command) { 'kill -9 $$' }
 
         it 'raises a SignalError specifying the status' do
-          expect { runner.execute(command) }.to(
-            raise_exception(PerconaMigrator::SignalError)
-          )
+          expect { runner.execute(command) }
+            .to raise_exception(PerconaMigrator::SignalError)
         end
       end
 
@@ -127,12 +125,11 @@ describe PerconaMigrator::Runner do
         let(:command) { 'whatevarrr666' }
 
         it 'raises a detailed CommandNotFoundError' do
-          expect { runner.execute(command) }.to(
-            raise_exception(
+          expect { runner.execute(command) }
+            .to raise_exception(
               PerconaMigrator::CommandNotFoundError,
               /Please install pt-online-schema-change/
             )
-          )
         end
       end
     end

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -10,8 +10,9 @@ describe PerconaMigrator::Runner do
   let(:mysql_adapter) do
     instance_double(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
   end
+  let(:config) { instance_double(PerconaMigrator::Configuration, tmp_path: 'percona_migrator_error.log') }
 
-  let(:runner) { described_class.new(logger, cli_generator, mysql_adapter) }
+  let(:runner) { described_class.new(logger, cli_generator, mysql_adapter, config) }
 
   describe '#query' do
   end
@@ -47,8 +48,7 @@ describe PerconaMigrator::Runner do
     end
     let(:stdout) { temp_file.open }
     let(:wait_thread) { instance_double(Thread, value: status) }
-    let(:error_log_path) { 'percona_migrator_error.log' }
-    let(:expected_command) { "#{command} 2> #{error_log_path}" }
+    let(:expected_command) { "#{command} 2> #{config.tmp_path}" }
 
     before do
       allow(Open3).to(
@@ -93,7 +93,7 @@ describe PerconaMigrator::Runner do
     end
 
     context 'on failure' do
-      let(:expected_command) { "#{command} 2> #{error_log_path}" }
+      let(:expected_command) { "#{command} 2> #{config.tmp_path}" }
 
       before do
         allow(Open3).to(

--- a/spec/percona_migrator/runner_spec.rb
+++ b/spec/percona_migrator/runner_spec.rb
@@ -10,7 +10,12 @@ describe PerconaMigrator::Runner do
   let(:mysql_adapter) do
     instance_double(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
   end
-  let(:config) { instance_double(PerconaMigrator::Configuration, tmp_path: 'percona_migrator_error.log') }
+  let(:config) do
+    instance_double(
+      PerconaMigrator::Configuration,
+      error_log_path: 'percona_migrator_error.log'
+    )
+  end
 
   let(:runner) { described_class.new(logger, cli_generator, mysql_adapter, config) }
 
@@ -48,7 +53,7 @@ describe PerconaMigrator::Runner do
     end
     let(:stdout) { temp_file.open }
     let(:wait_thread) { instance_double(Thread, value: status) }
-    let(:expected_command) { "#{command} 2> #{config.tmp_path}" }
+    let(:expected_command) { "#{command} 2> #{config.error_log_path}" }
 
     before do
       allow(Open3).to(
@@ -93,7 +98,7 @@ describe PerconaMigrator::Runner do
     end
 
     context 'on failure' do
-      let(:expected_command) { "#{command} 2> #{config.tmp_path}" }
+      let(:expected_command) { "#{command} 2> #{config.error_log_path}" }
 
       before do
         allow(Open3).to(

--- a/spec/percona_migrator_spec.rb
+++ b/spec/percona_migrator_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe PerconaMigrator do
+  describe '.config' do
+    subject { described_class.config }
+    it { is_expected.to be_a(PerconaMigrator::Configuration) }
+  end
+end

--- a/spec/percona_migrator_spec.rb
+++ b/spec/percona_migrator_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 describe PerconaMigrator do
-  describe '.config' do
-    subject { described_class.config }
-    it { is_expected.to be_a(PerconaMigrator::Configuration) }
+  describe '.configure' do
+    it 'yields the configuration object' do
+      expect do |b|
+        described_class.configure(&b)
+      end.to yield_with_args(kind_of(PerconaMigrator::Configuration))
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,10 @@ test_database = TestDatabase.new(db_config)
 RSpec.configure do |config|
   ActiveRecord::Migration.verbose = false
 
+  # Needs an empty block to initialize the config with the default values
+  PerconaMigrator.configure do |config|
+  end
+
   config.around(:each) do |example|
 
     # Cleans up the database before each example, so the current example doesn't


### PR DESCRIPTION
### WAT

Until now executing the standard output and standard error of the process running the percona toolkit was showed at the end all at once without giving any feedback to the user while running long migrations...

With this PR we'll see the standard output coming out during the migration and, in case of error, we'll be able to check the standard error in the generated `percona_migrator_error.log` file.
### TODO
- [x] Move the `percona_migrator_error.log` to Rails temp directory
