### PR TITLE
Doc how to release considering the branch strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ git commits and tags, and push the `.gem` file to
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-https://github.com/redbooth/percona_migrator.
+https://github.com/redbooth/percona_migrator. They need to be opened against
+`master` or `v3.2` only if the changes fix a bug in Rails 3.2 apps.
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,10 @@ All releases come from the master branch. Only those releases that add a fix for
 the Rails 3.2 support will come from the branch v3.2. Keep in mind though, that
 said branch is not actively maintained.
 
+In order to give support to a new major Rails version, we'll branch off of
+master, name it following the Rails repo convention, such as `v4.2`, and
+we'll keep it open for bug fixes.
+
 1. Update `lib/percona_migrator/version.rb` accordingly
 2. Review the `CHANGELOG.md` and add a new section following the format
    `[version] - YYYY-MM-DD`. We conform to the guidelines of

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,7 @@
 # Releasing Percona Migrator
 
-All releases come from the master branch. Only those releases that add a fix for
-the Rails 3.2 support will come from the branch v3.2. Keep in mind though that
-said branch is not actively maintained.
+All releases come from the master branch. All other branches won't be maintained
+and will receive bug fix releases only.
 
 In order to give support to a new major Rails version, we'll branch off of
 master, name it following the Rails repo convention, such as `v4.2`, and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,14 @@
+# Releasing Percona Migrator
+
+All releases come from the master branch. Only those releases that add a fix for
+the Rails 3.2 support will come from the branch v3.2. Keep in mind though, that
+said branch is not actively maintained.
+
+1. Update `lib/percona_migrator/version.rb` accordingly
+2. Review the `CHANGELOG.md` and add a new section following the format
+   `[version] - YYYY-MM-DD`. We conform to the guidelines of
+   http://keepachangelog.com/
+3. Commit the changes with the message `Prepare release VERSION`
+4. Execute the release rake task as `bundle exec rake release`. It creates the
+   tag, builds and pushes the gem to Rubygems.
+5. Announce it! :tada:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing Percona Migrator
 
 All releases come from the master branch. Only those releases that add a fix for
-the Rails 3.2 support will come from the branch v3.2. Keep in mind though, that
+the Rails 3.2 support will come from the branch v3.2. Keep in mind though that
 said branch is not actively maintained.
 
 In order to give support to a new major Rails version, we'll branch off of


### PR DESCRIPTION
We state that we'll keep a branch for every Rails major version we support plus the necessary steps to create a new release.