### PR TITLE
Use pt-osc's default value for --recursion-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
    `PERCONA_ARGS` env var when executing a migration with `rake db:migrate:up`
    or `db:migrate:down`.
 
+### Changed
+
+- Enable default pt-online-schema-change replicas discovering mechanism.
+    So far, this was purposely set to `none`. To keep this same behaviour
+    provide the `PERCONA_ARGS=--recursion-method=none` env var when running the
+    migration.
+
 ## [1.0.0] - 2016-11-30
 
 ### Added

--- a/lib/percona_migrator/cli_generator.rb
+++ b/lib/percona_migrator/cli_generator.rb
@@ -18,7 +18,6 @@ module PerconaMigrator
       [
         Option.new('execute'),
         Option.new('statistics'),
-        Option.new('recursion-method', 'none'),
         Option.new('alter-foreign-keys-method', 'auto'),
         Option.new('no-check-alter')
       ]


### PR DESCRIPTION
We were specifying `--recursion-method=none`, which makes pt-osc not to
consider replicas. We can still provide the same behaviour using the
PERCONA_ARGS env var, while allowing others to rely on pt-osc's default
behaviour. Usually, you do care about the impact on your replicas.