### PR TITLE
Show how to install DBI and DBD::mysql from cpan

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ Toolkit](https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change
 
 `brew install percona-toolkit`
 
+If when running a migration you see an error like:
+
+```
+PerconaMigrator::Error: Cannot connect to MySQL: Cannot connect to MySQL because
+the Perl DBI module is not installed or not found.
+```
+
+You also need to install the DBI and DBD::MySQL modules from `cpan`.
+
+```
+$ sudo cpan
+cpan> install DBI
+cpan> install DBD::mysql
+```
+
 ### Linux
 
 #### Ubuntu/Debian based


### PR DESCRIPTION
The way homebrew installs percona-toolkit these modules can't be found
when running the migration.

We recently had an issue related to it https://github.com/redbooth/percona_migrator/issues/42