### PR TITLE
Relax runtime dep on mysql2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 - Store pt-online-schema-change's stderr to percona_migrator_error.log in the
     default Rails tmp folder.
 - Allow configuring the tmp directory where the error log gets written into,
-    with the `tmp_path` configuration setting.
+- No longer a hard dependency on mysql2 0.3.20.  Will accept 0.3.20 or any
+    higher patch revisions.
 
 ## [0.1.0.rc.7] - 2016-09-15
 

--- a/percona_migrator.gemspec
+++ b/percona_migrator.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  # TODO: Relax me
   spec.add_runtime_dependency 'rails', '~>3.2.22'
-  spec.add_runtime_dependency 'mysql2', '0.3.20'
+  spec.add_runtime_dependency 'mysql2', '~>0.3.20'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Right now there's a hard dependency on mysql2 v0.3.20.  However, the current version is v0.3.21.  This PR implements what the comment said ;)