### PR TITLE
Add deprecation warning to inform about the rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Percona Migrator [![Build Status](https://travis-ci.org/redbooth/percona_migrator.svg?branch=master)](https://travis-ci.org/redbooth/percona_migrator) [![Code Climate](https://codeclimate.com/github/redbooth/percona_migrator/badges/gpa.svg)](https://codeclimate.com/github/redbooth/percona_migrator)
+# Departure [![Build Status](https://travis-ci.org/redbooth/departure.svg?branch=master)](https://travis-ci.org/redbooth/percona_migrator) [![Code Climate](https://codeclimate.com/github/redbooth/percona_migrator/badges/gpa.svg)](https://codeclimate.com/github/redbooth/percona_migrator)
 
-Percona Migrator is an **ActiveRecord connection adapter** that allows running
+Departure is an **ActiveRecord connection adapter** that allows running
 **MySQL online and non-blocking DDL** through `ActiveRecord::Migration` without needing
     to use a different DSL other than Rails' migrations DSL.
 
@@ -9,9 +9,17 @@ It uses `pt-online-schema-change` command-line tool of
 Toolkit](https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html)
 which runs MySQL alter table statements without downtime.
 
+## Rename from "Percona Migrator"
+
+This project was formerly known as "Percona Migrator", but this incurs in an
+infringement of Percona's trade mark policy and thus has to be renamed. Said
+name is likely to cause confusion as to the source of the wrapper.
+
+The next major versions will use "Departure" as gem name.
+
 ## Installation
 
-Percona Migrator relies on `pt-online-schema-change` from [Percona
+Departure relies on `pt-online-schema-change` from [Percona
 Toolkit](https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html)
 
 ### Mac
@@ -99,7 +107,7 @@ vary depending on the database table and the kind of changes you apply.
 ### LHM support
 
 If you moved to Soundcloud's [Lhm](https://github.com/soundcloud/lhm) already,
-we got you covered. Percona Migrator overrides Lhm's DSL so that all the alter
+we got you covered. Departure overrides Lhm's DSL so that all the alter
 statements also go through `pt-online-schema-change` as well.
 
 You can keep your Lhm migrations and start using Rails migration's DSL back
@@ -120,7 +128,7 @@ It's strongly recommended to name it after this gems name, such as
 
 ## How it works
 
-When booting your Rails app, Percona Migrator extends the
+When booting your Rails app, Departure extends the
 `ActiveRecord::Migration#migrate` method to reset the connection and reestablish
 it using the `PerconaAdapter` instead of the one you defined in your
 `config/database.yml`.

--- a/lib/percona_migrator/command.rb
+++ b/lib/percona_migrator/command.rb
@@ -23,9 +23,13 @@ module PerconaMigrator
     #
     # @return [Process::Status]
     def run
+      log_deprecations
       log_started
+
       run_in_process
+
       log_finished
+
       validate_status!
       status
     end
@@ -88,6 +92,11 @@ module PerconaMigrator
     # print by the migration
     def log_finished
       logger.write("\n")
+    end
+
+    def log_deprecations
+      logger.write("\n")
+      logger.write("[DEPRECATION] This gem has been renamed to Departure and will no longer be supported. Please switch to Departure as soon as possible.")
     end
   end
 end

--- a/percona_migrator.gemspec
+++ b/percona_migrator.gemspec
@@ -15,6 +15,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/redbooth/percona_migrator'
   spec.license       = 'MIT'
 
+  spec.post_install_message = <<-MESSAGE
+  !    The Percona_migrator gem has been deprecated and has been replaced by Departure.
+  !    See: https://rubygems.org/gems/departure
+  !    And: https://github.com/redbooth/departure
+  MESSAGE
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
That's it. We need to let everyone know that we'll rename the gem to `departure`. To that end, this adds post-install message

```shell
$ gem install pkg/percona_migrator-1.0.0.gem
  !    The Percona_migrator gem has been deprecated and has been replaced by Departure.
  !    See: https://rubygems.org/gems/departure
  !    And: https://github.com/redbooth/departure
Successfully installed percona_migrator-1.0.0
Parsing documentation for percona_migrator-1.0.0
Done installing documentation for percona_migrator after 0 seconds
1 gem installed
```

and a depreaction warning when running a migration

```shell
(...)
[DEPRECATION] This gem has been renamed to Departure and will no longer be supported. Please switch to Departure as soon as possible.

   -> Running pt-online-schema-change -h localhost -u root  --execute --statistics --alter-foreign-keys-method=auto --no-check-alter D=perco
na_migrator_test,t=comments --alter "ADD \`read\` tinyint(1) DEFAULT 0 NOT NULL"
(...)
```

I'm following the guidelines in http://stackoverflow.com/a/14149821/2838228. Any other idea?