### PR TITLE
Global percona args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 - Allow passing any `pt-online-schema-change`'s arguments through the
    `PERCONA_ARGS` env var when executing a migration with `rake db:migrate:up`
    or `db:migrate:down`.
+- Allow setting global percona arguments via gem configuration   
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ migration.
 
 ### pt-online-schema-change arguments
 
+#### with environment variable
+
 You can specify any `pt-online-schema-change` arguments when running the
 migration. All what you pass in the PERCONA_ARGS env var, will be bypassed to the
 binary, overwriting any default values. Note the format is the same as in
@@ -103,6 +105,24 @@ $ PERCONA_ARGS='--chunk-time=1 --critical-load=55' bundle exec rake db:migrate:u
 This however, only works for `db:migrate:up` or `db:migrate:down` rake tasks and
 not with `db:migrate`. The settings you provide can't be generalized as these
 vary depending on the database table and the kind of changes you apply.
+
+#### with global configuration
+
+You can specify any `pt-online-schema-change` arguments in global gem configuration
+using `global_percona_args` option.
+
+```ruby
+PerconaMigrator.configure do |config|
+  config.global_percona_args = '--chunk-time=1 --critical-load=55'
+end
+```
+
+Unlike using `PERCONA_ARGS`, options provided with global configuration will be applied 
+every time sql command is executed via `pt-online-schema-change`.
+ 
+Arguments provided in global configuration can be overwritten with `PERCONA_ARGS` env variable. 
+
+We recommend using this option with caution and only when you understand the consequences.
 
 ### LHM support
 

--- a/lib/percona_migrator/cli_generator.rb
+++ b/lib/percona_migrator/cli_generator.rb
@@ -76,9 +76,10 @@ module PerconaMigrator
     #
     # @return [String]
     def all_options
-      user_options = UserOptions.new
-      options = user_options.merge(DEFAULT_OPTIONS).to_a
-      options.join(' ')
+      env_variable_options = UserOptions.new
+      global_configuration_options = UserOptions.new(PerconaMigrator.configuration.global_percona_args)
+      options = env_variable_options.merge(global_configuration_options).merge(DEFAULT_OPTIONS)
+      options.to_a.join(' ')
     end
   end
 end

--- a/lib/percona_migrator/configuration.rb
+++ b/lib/percona_migrator/configuration.rb
@@ -1,10 +1,11 @@
 module PerconaMigrator
   class Configuration
-    attr_accessor :tmp_path
+    attr_accessor :tmp_path, :global_percona_args
 
     def initialize
       @tmp_path = '.'.freeze
       @error_log_filename = 'percona_migrator_error.log'.freeze
+      @global_percona_args = nil
     end
 
     def error_log_path

--- a/lib/percona_migrator/user_options.rb
+++ b/lib/percona_migrator/user_options.rb
@@ -1,8 +1,6 @@
 module PerconaMigrator
   # Encapsulates the pt-online-schema-change options defined by the user
   class UserOptions
-    # include Enumerable
-
     delegate :each, :merge, to: :to_set
 
     # Constructor

--- a/lib/percona_migrator/user_options.rb
+++ b/lib/percona_migrator/user_options.rb
@@ -1,7 +1,9 @@
 module PerconaMigrator
   # Encapsulates the pt-online-schema-change options defined by the user
   class UserOptions
-    delegate :merge, to: :to_set
+    # include Enumerable
+
+    delegate :each, :merge, to: :to_set
 
     # Constructor
     #


### PR DESCRIPTION
This pull request solves issue #50 - it adds `global_percona_args` configuration option that allows to specify some arguments that will be used every time when sql command is executed via `pt-online-schema-change`. Values provided there can be change by `PERCONA_ARGS` env variable.