### PR TITLE
Fix table_rename and rename_index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 /tmp/
 .byebug_history
 tags
-percona_migrator_error.log
+departure_error.log

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -51,7 +51,8 @@ module ActiveRecord
 
       ADAPTER_NAME = 'Percona'.freeze
 
-      def_delegators :mysql_adapter, :last_inserted_id, :each_hash, :set_field_encoding
+      def_delegators :mysql_adapter, :last_inserted_id, :each_hash,
+                     :set_field_encoding, :full_version
 
       def initialize(connection, _logger, connection_options, _config)
         super

--- a/lib/lhm/column_with_sql.rb
+++ b/lib/lhm/column_with_sql.rb
@@ -2,8 +2,8 @@ require 'forwardable'
 
 module Lhm
 
-  # Abstracts the details of a table column definition when specified with a MySQL
-  # column definition string
+  # Abstracts the details of a table column definition when specified with a
+  # MySQL column definition string
   class ColumnWithSql
     extend Forwardable
 

--- a/spec/lhm/column_with_sql_spec.rb
+++ b/spec/lhm/column_with_sql_spec.rb
@@ -97,7 +97,7 @@ describe Lhm::ColumnWithSql do
       let(:definition) { 'FLOAT' }
 
       its([0]) { is_expected.to eq(:float) }
-      its([1]) { is_expected.to eq(limit: nil, default: nil, null: true) }
+      its([1]) { is_expected.to eq(limit: 24, default: nil, null: true) }
 
       context 'with DEFAULT' do
         subject { column.attributes[1] }


### PR DESCRIPTION
This fixes the `#rename_table` and `#rename_index` migration methods in Rails v4.1. This was due to missing `#full_version` in the connection adapter, which is a method the `AbstractMysqlAdapter` calls on its subclasses.