### PR TITLE
Adds support for all pt-online-schema-change command-line options

### DIFF
--- a/lib/departure/option.rb
+++ b/lib/departure/option.rb
@@ -3,15 +3,11 @@ module Departure
     attr_reader :name, :value
 
     # Builds an instance by parsing its name and value out of the given string.
-    # Note the string must conform to "--<arg>=<value>" format.
     #
     # @param string [String]
     # @return [Option]
     def self.from_string(string)
-      pair = string.split('=')
-      name = pair[0][2..-1]
-      value = pair[1]
-
+      name, value = string.split(/\s|=/, 2)
       new(name, value)
     end
 
@@ -20,7 +16,7 @@ module Departure
     # @param name [String]
     # @param optional value [String]
     def initialize(name, value = nil)
-      @name = name
+      @name = normalize_option(name)
       @value = value
     end
 
@@ -40,14 +36,28 @@ module Departure
       name.hash
     end
 
-    # Returns the option as string following the "--<name>=<value>" format
+    # Returns the option as string following the "--<name>=<value>" format or
+    # the short "-n=value" format
     #
     # @return [String]
     def to_s
-      "--#{name}#{value_as_string}"
+      "#{name}#{value_as_string}"
     end
 
     private
+
+    # Returns the option name in "long" format, e.g., "--name"
+    #
+    # @return [String]
+    def normalize_option(name)
+      if name.start_with?('-')
+        name
+      elsif name.length == 1
+        "-#{name}"
+      else
+        "--#{name}"
+      end
+    end
 
     # Returns the value fragment of the option string if any value is specified
     #
@@ -55,6 +65,8 @@ module Departure
     def value_as_string
       if value.nil?
         ''
+      elsif value.include?("=")
+        " #{value}"
       else
         "=#{value}"
       end

--- a/lib/departure/user_options.rb
+++ b/lib/departure/user_options.rb
@@ -36,7 +36,7 @@ module Departure
     #
     # @return [Array<Option>]
     def build_options
-      arguments.split(' ').map do |argument|
+      arguments.split(/\s(?=-)/).map do |argument|
         Option.from_string(argument)
       end
     end

--- a/spec/departure/cli_generator_spec.rb
+++ b/spec/departure/cli_generator_spec.rb
@@ -49,6 +49,11 @@ describe Departure::CliGenerator do
       let(:env_var) { { PERCONA_ARGS: '--chunk-time=1' } }
       it { is_expected.to include('--chunk-time=1') }
 
+      context 'when the option includes an array argument' do
+        let(:env_var) { { PERCONA_ARGS: '--max-load Threads_running=30' } }
+        it { is_expected.to include('--max-load Threads_running=30') }
+      end
+
       context 'when the option has a default' do
         let(:env_var) { { PERCONA_ARGS: '--alter-foreign-keys-method=drop_swap' } }
 
@@ -74,6 +79,11 @@ describe Departure::CliGenerator do
       let(:global_percona_args) { '--chunk-time=1'}
 
       it { is_expected.to include('--chunk-time=1') }
+
+      context 'when the option includes an array argument' do
+        let(:global_percona_args) { '--max-load Threads_running=30' }
+        it { is_expected.to include('--max-load Threads_running=30') }
+      end
 
       context 'when the option has a default' do
         let(:global_percona_args) { '--alter-foreign-keys-method=drop_swap' }

--- a/spec/departure/option_spec.rb
+++ b/spec/departure/option_spec.rb
@@ -3,8 +3,55 @@ require 'spec_helper'
 describe Departure::Option do
   describe '.from_string' do
     it 'gets the name and value' do
-      expect(described_class).to receive(:new).with('arg', 'value')
+      expect(described_class).to receive(:new).with('--arg', 'value')
       described_class.from_string('--arg=value')
+    end
+
+    context 'when given a name in short form' do
+      it 'gets the short name and value' do
+        expect(described_class).to receive(:new).with('-A', 'utf8')
+        described_class.from_string('-A utf8')
+      end
+    end
+
+    context 'when given a name only' do
+      it 'gets the name' do
+        expect(described_class).to receive(:new).with('--quiet', nil)
+        described_class.from_string('--quiet')
+      end
+
+      context 'in short form' do
+        it 'gets the short name' do
+          expect(described_class).to receive(:new).with('-q', nil)
+          described_class.from_string('-q')
+        end
+      end
+    end
+
+    context 'when given an array value' do
+      it 'gets the name and array value' do
+        expect(described_class).to receive(:new).with('--max-load', 'Threads_running=100,Threads_created=500')
+        described_class.from_string('--max-load Threads_running=100,Threads_created=500')
+      end
+    end
+  end
+
+  describe '#name' do
+    subject { option.name }
+
+    context 'when option is initialized with a long-named command-line argument' do
+      let(:option) { described_class.new('--dry-run') }
+      it { is_expected.to eq('--dry-run') }
+    end
+
+    context 'when option is initialized with a short form command-line argument' do
+      let(:option) { described_class.new('-q') }
+      it { is_expected.to eq('-q') }
+    end
+
+    context 'when option is initialized with a name' do
+      let(:option) { described_class.new('no-check-alter') }
+      it { is_expected.to eq('--no-check-alter') }
     end
   end
 
@@ -42,7 +89,7 @@ describe Departure::Option do
     subject { option.hash }
     let(:option) { described_class.new('arg', 'bar') }
 
-    it { is_expected.to eq('arg'.hash) }
+    it { is_expected.to eq('--arg'.hash) }
   end
 
   describe '#to_s' do
@@ -56,6 +103,11 @@ describe Departure::Option do
     context 'when there is value' do
       let(:option) { described_class.new('arg', 'bar') }
       it { is_expected.to eq('--arg=bar') }
+    end
+
+    context 'when the value is an array' do
+      let(:option) { described_class.new('max-load', 'Threads_running=50') }
+      it { is_expected.to eq('--max-load Threads_running=50') }
     end
   end
 end


### PR DESCRIPTION
Extends the options builder to accept (hopefully) all supported
pt-online-schema-change options, including short forms (e.g,. `-A`) and
array arguments (e.g., `--max-load Threads_running=30`).